### PR TITLE
Harden the book organiser, add a test suite, and support beta releases

### DIFF
--- a/.github/release-body-beta.md
+++ b/.github/release-body-beta.md
@@ -5,6 +5,24 @@
 A stability-focused release for the book organiser. The sorting engine has been reworked so that
 a run is predictable, repeatable, and safe to interrupt.
 
+## New: choose how books are kept up to date
+
+Publishers re-issue audiobooks, and a sort should replace the copy in your organized library rather
+than leave the old one behind. Every run already compares each book against the destination and
+only writes when they differ; the Sort page now lets you choose *how closely* it compares.
+
+- **Quick** (default, and what previous versions did) — file size plus the first, middle and last
+  4 KB. It catches any re-release whose length changed, which is nearly all of them, and costs
+  almost nothing to run over a large library.
+- **Verify contents** — compares every byte, and replaces any book that changed at all. Slower,
+  because it reads both files in full, but it also catches a re-issue that happens to be exactly
+  the same size as the copy you already have.
+
+Books that already match are left untouched either way. The progress panel now reports **Updated**
+— books replaced because their source had changed — separately from books copied for the first
+time. In Docker, set the default with `COMPARISON_MODE=quick|full`; the Sort page still overrides
+it for an individual run.
+
 ## Fixes
 
 **Your library is no longer rewritten by a sort.** Sorting used to overwrite the in-memory book
@@ -60,12 +78,14 @@ folder is refused, and progress now reports copied, skipped and failed counts se
 - Copy concurrency is capped at 8 and can be set with the `OABO_MAX_PARALLELISM` environment
   variable.
 - `POST /api/books/parse` now returns `{ books, skippedRows, warnings }` instead of a bare array.
+- `POST /api/sort/start` accepts an optional `comparisonMode` of `"quick"` or `"full"`; omitting it
+  uses the server default. Sort progress gained an `updatedBooks` count.
 
 ## Testing
 
-This release adds a test suite (140 tests) covering path safety, name resolution, planning
-determinism, atomic and idempotent copying, cancellation, and CSV robustness, plus a CI workflow
-that runs it on Linux and Windows.
+This release adds a test suite (171 tests) covering path safety, name resolution, planning
+determinism, atomic and idempotent copying, both update checks, cancellation, and CSV robustness,
+plus a CI workflow that runs it on Linux and Windows.
 
 ## Feedback
 

--- a/.github/release-body-beta.md
+++ b/.github/release-body-beta.md
@@ -23,6 +23,20 @@ Books that already match are left untouched either way. The progress panel now r
 time. In Docker, set the default with `COMPARISON_MODE=quick|full`; the Sort page still overrides
 it for an individual run.
 
+## Fixed since beta.1
+
+**The library list was ordering two columns wrongly.** Sorting by Duration compared the raw text
+OpenAudible writes ("45 mins", "9 hrs and 9 mins"), so a 45 minute book was filed *after* a nine
+hour one — 45 reads as larger than 9. Sorting by Series compared the series name alone, leaving
+every book in a series tied and in whatever order the export happened to use, which routinely put
+#10 above #2. Both now sort on what the column means rather than how the value is spelled.
+
+**Linux windows are associated with the installed app.** The `.desktop` entry's name did not match
+the window class, so a running window appeared as a separate generic entry rather than grouping
+under the app.
+
+The desktop and web interface has also been rebuilt — see below.
+
 ## Fixes
 
 **Your library is no longer rewritten by a sort.** Sorting used to overwrite the in-memory book
@@ -81,11 +95,34 @@ folder is refused, and progress now reports copied, skipped and failed counts se
 - `POST /api/sort/start` accepts an optional `comparisonMode` of `"quick"` or `"full"`; omitting it
   uses the server default. Sort progress gained an `updatedBooks` count.
 
+## A rebuilt interface
+
+The app has been reworked to stay usable with a large collection and to get out of the way.
+
+- **A 5,000 book library now renders in about a quarter of a second instead of four and a half
+  seconds.** Only the rows near the viewport are built, so the browser holds a few hundred elements
+  rather than 120,000, and scrolling stays smooth however large the collection is.
+- Searching is debounced and no longer re-sorts on every keystroke; the list returns to the top
+  when the results change instead of stranding you in the middle of a list that no longer exists.
+- The list is a real table with sortable headers, so screen readers can navigate it and it reports
+  the true size of your library.
+- Narrow windows shed optional columns and collapse the sidebar to icons rather than squeezing
+  everything into ellipses.
+- Durations read "12h 34m" rather than truncating to "12 hrs and…".
+- Flatter, quieter visuals: one accent colour, no gradients or glow, and text that meets the
+  WCAG AA contrast minimum on every surface it sits on.
+
 ## Testing
 
-This release adds a test suite (171 tests) covering path safety, name resolution, planning
-determinism, atomic and idempotent copying, both update checks, cancellation, and CSV robustness,
-plus a CI workflow that runs it on Linux and Windows.
+178 backend tests cover path safety, name resolution, planning determinism, atomic and idempotent
+copying, both update checks, cancellation and CSV robustness. 20 frontend tests cover the search
+and ordering rules, including regression tests for the two sorting bugs above. Both suites run in
+CI on Linux and Windows, and now gate the release itself.
+
+This beta was also driven by hand against a deliberately hostile library — books with no author,
+no series and no duration, a 400 character title, Arabic and Japanese text, emoji, markup in a
+title, and duplicate titles — checking that nothing crashed, nothing was written outside the
+destination folder, and a second run copied nothing.
 
 ## Feedback
 

--- a/.github/release-body-beta.md
+++ b/.github/release-body-beta.md
@@ -1,0 +1,73 @@
+> **This is a beta release.** It is published for testing and is not marked as the latest
+> release. The Docker `latest` tag still points at the most recent stable version — pull the
+> exact version tag to try this build.
+
+A stability-focused release for the book organiser. The sorting engine has been reworked so that
+a run is predictable, repeatable, and safe to interrupt.
+
+## Fixes
+
+**Your library is no longer rewritten by a sort.** Sorting used to overwrite the in-memory book
+list with its own cleaned-up values, so the Library view changed after every run and a second run
+worked from different data than the first. Sorting is now read-only with respect to your library.
+
+**One author, one folder.** Folder names are now decided once, in list order, before any copying
+starts. Previously, parallel workers could each decide independently how to spell an author, and
+the same author could end up split across `J.K. Rowling` and `JK Rowling` in the same run.
+
+**Books can no longer overwrite each other.** Two books that resolved to the same file name used
+to silently overwrite one another — and if the export had no `Short Title` column, *every* book
+was named `Unknown` and only the last one survived. The organiser now falls back through Short
+Title, Title and file name, and gives genuinely clashing names a numbered suffix.
+
+**Interrupted runs no longer leave broken files.** Files are copied to a temporary file and then
+renamed into place, so cancelling a sort, closing the app, or filling the disk can no longer leave
+a half-written book that a later run mistakes for a complete one.
+
+**Failures are reported instead of swallowed.** A missing source folder used to be logged to a
+console nobody sees while the UI waited forever for a run that had already given up. Paths are now
+validated before a run starts, and errors surface in the app.
+
+**Imports survive imperfect exports.** A single blank rating, an unparseable date, a missing
+column or one malformed row used to fail the entire import. Rows are now skipped individually and
+reported, and every column is optional. Tab-separated exports and files with a byte-order mark are
+read correctly.
+
+**More of your files are found.** Audio files are now located even when the `M4B`/`MP3` columns
+are empty, and Windows-style paths in `File Paths` are matched on Linux and macOS.
+
+**No more empty folder trees.** Author and series folders are only created when there is actually
+something to copy into them.
+
+**Desktop app.** A second copy of the app no longer fights the first one for the backend port, and
+a backend that fails to start or dies mid-session now says so instead of leaving the window
+unresponsive.
+
+**Web/Docker app.** Starting two sorts at once is properly rejected, sorting into your own source
+folder is refused, and progress now reports copied, skipped and failed counts separately.
+
+## Behaviour changes worth knowing about
+
+- **File names are now sanitised the same way on every platform.** Characters that are illegal on
+  Windows (`: ? * " < > | \ /`) are stripped on Linux and macOS too, so a library stays portable to
+  a NAS or an external drive. Existing author and series folders are detected and reused, and an
+  existing file whose name differs only by those characters is reused rather than duplicated — but
+  if you organised a library on Linux you may still see a small number of renamed files.
+- Very long names are truncated to 200 characters, which previously failed the copy outright.
+- Names that Windows reserves (`CON`, `NUL`, `COM1`…) are prefixed with `_`.
+- Copy concurrency is capped at 8 and can be set with the `OABO_MAX_PARALLELISM` environment
+  variable.
+- `POST /api/books/parse` now returns `{ books, skippedRows, warnings }` instead of a bare array.
+
+## Testing
+
+This release adds a test suite (136 tests) covering path safety, name resolution, planning
+determinism, atomic and idempotent copying, cancellation, and CSV robustness, plus a CI workflow
+that runs it on Linux and Windows.
+
+## Feedback
+
+Please report anything you hit against this beta on the
+[issue tracker](https://github.com/orbitalteapot/OpenAudible-BookOrganizer/issues) — especially
+unexpected folder names, files that were not found, or anything that looks renamed after
+upgrading.

--- a/.github/release-body-beta.md
+++ b/.github/release-body-beta.md
@@ -34,7 +34,9 @@ reported, and every column is optional. Tab-separated exports and files with a b
 read correctly.
 
 **More of your files are found.** Audio files are now located even when the `M4B`/`MP3` columns
-are empty, and Windows-style paths in `File Paths` are matched on Linux and macOS.
+are empty, and a `File Paths` entry that records where a file *used to* live — another machine,
+another drive letter, a path written on Windows and read on Linux — falls back to the file name
+inside the source folder you chose.
 
 **No more empty folder trees.** Author and series folders are only created when there is actually
 something to copy into them.
@@ -61,7 +63,7 @@ folder is refused, and progress now reports copied, skipped and failed counts se
 
 ## Testing
 
-This release adds a test suite (138 tests) covering path safety, name resolution, planning
+This release adds a test suite (140 tests) covering path safety, name resolution, planning
 determinism, atomic and idempotent copying, cancellation, and CSV robustness, plus a CI workflow
 that runs it on Linux and Windows.
 

--- a/.github/release-body-beta.md
+++ b/.github/release-body-beta.md
@@ -61,7 +61,7 @@ folder is refused, and progress now reports copied, skipped and failed counts se
 
 ## Testing
 
-This release adds a test suite (136 tests) covering path safety, name resolution, planning
+This release adds a test suite (138 tests) covering path safety, name resolution, planning
 determinism, atomic and idempotent copying, cancellation, and CSV robustness, plus a CI workflow
 that runs it on Linux and Windows.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend build and tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # The sorter writes paths, so it is checked on both path flavours.
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore OpenAudibleBookManager.sln
+
+      - name: Build
+        run: dotnet build OpenAudibleBookManager.sln -c Release --no-restore
+
+      - name: Test
+        run: dotnet test OpenAudibleBookManager.sln -c Release --no-build --verbosity normal
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: electron-ui/package-lock.json
+
+      - name: Install dependencies
+        working-directory: electron-ui
+        run: npm ci
+
+      - name: Build
+        working-directory: electron-ui
+        run: npm run build
+
+  docker:
+    name: Docker image builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
+        with:
+          context: .
+          file: ManagerApi/Dockerfile
+          push: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
         working-directory: electron-ui
         run: npm ci
 
+      - name: Run frontend tests
+        working-directory: electron-ui
+        run: npm test
+
       - name: Build
         working-directory: electron-ui
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,22 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: electron-ui/package-lock.json
+
       - name: Run backend tests
         run: dotnet test OpenAudibleBookManager.sln -c Release
+
+      - name: Install frontend dependencies
+        working-directory: electron-ui
+        run: npm ci
+
+      - name: Run frontend tests
+        working-directory: electron-ui
+        run: npm test
 
   # ── Windows x64 NSIS installer ───────────────────────────────────────────────
   build-windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number to release and tag (e.g. 1.2.3)'
+        description: 'Version to release and tag (e.g. 1.2.3, or 1.2.3-beta.1 for a pre-release)'
         required: true
         type: string
   push:
@@ -28,8 +28,8 @@ jobs:
 
       - name: Validate version format
         run: |
-          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Error: version must be in X.Y.Z format (e.g. 1.2.3)"
+          if ! echo "${{ inputs.version }}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+            echo "Error: version must be X.Y.Z or X.Y.Z-<pre-release> (e.g. 1.2.3, 1.2.3-beta.1)"
             exit 1
           fi
 
@@ -61,6 +61,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
       major_minor: ${{ steps.version.outputs.major_minor }}
       tag: ${{ steps.version.outputs.tag }}
+      is_prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
       - name: Compute version
         id: version
@@ -70,18 +71,45 @@ jobs:
           else
             VERSION="${GITHUB_REF_NAME}"
           fi
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "Error: release tag must be in X.Y.Z format (for example 1.2.3)"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+            echo "Error: release tag must be X.Y.Z or X.Y.Z-<pre-release> (for example 1.2.3, 1.2.3-beta.1)"
             exit 1
           fi
+
+          # 1.2.3-beta.1 is a pre-release: it is published, but it must not become the version
+          # that 'latest' or the X.Y Docker tag point at.
+          CORE="${VERSION%%-*}"
+          if [ "$CORE" != "$VERSION" ]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "major_minor=${VERSION%.*}" >> $GITHUB_OUTPUT
+          echo "major_minor=${CORE%.*}" >> $GITHUB_OUTPUT
           echo "tag=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+          echo "Releasing $VERSION (pre-release: $IS_PRERELEASE)"
+
+  # ── Build and test before anything is published ──────────────────────────────
+  verify:
+    name: Build and test
+    needs: [resolve-version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run backend tests
+        run: dotnet test OpenAudibleBookManager.sln -c Release
 
   # ── Windows x64 NSIS installer ───────────────────────────────────────────────
   build-windows:
     name: Windows x64 installer
-    needs: [resolve-version]
+    needs: [resolve-version, verify]
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -117,7 +145,7 @@ jobs:
   # ── Linux x64 installers (AppImage + deb) ───────────────────────────────────
   build-linux:
     name: Linux x64 installers
-    needs: [resolve-version]
+    needs: [resolve-version, verify]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -157,7 +185,7 @@ jobs:
   # ── macOS x64 installer (dmg) ────────────────────────────────────────────────
   build-mac-x64:
     name: macOS x64 installer
-    needs: [resolve-version]
+    needs: [resolve-version, verify]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -198,7 +226,7 @@ jobs:
   # ── macOS arm64 installer (dmg) ──────────────────────────────────────────────
   build-mac-arm64:
     name: macOS arm64 installer
-    needs: [resolve-version]
+    needs: [resolve-version, verify]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
@@ -238,7 +266,7 @@ jobs:
   # ── Docker image → ghcr.io ───────────────────────────────────────────────────
   build-docker:
     name: Docker image (Web App)
-    needs: [resolve-version]
+    needs: [resolve-version, verify]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -257,10 +285,12 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/OpenAudible-BookOrganizer
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          # A pre-release is published under its exact version only: 'latest' and the X.Y tag
+          # must keep pointing at the last stable release.
           tags: |
             type=raw,value=${{ needs.resolve-version.outputs.version }}
-            type=raw,value=${{ needs.resolve-version.outputs.major_minor }}
-            type=raw,value=latest
+            type=raw,value=${{ needs.resolve-version.outputs.major_minor }},enable=${{ needs.resolve-version.outputs.is_prerelease == 'false' }}
+            type=raw,value=latest,enable=${{ needs.resolve-version.outputs.is_prerelease == 'false' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -292,12 +322,22 @@ jobs:
         with:
           path: artifacts
 
+      - name: Choose release notes
+        id: notes
+        run: |
+          if [ "${{ needs.resolve-version.outputs.is_prerelease }}" == "true" ] && [ -f .github/release-body-beta.md ]; then
+            echo "path=.github/release-body-beta.md" >> $GITHUB_OUTPUT
+          else
+            echo "path=.github/release-body.md" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.resolve-version.outputs.tag }}
           name: OpenAudible Book Organizer ${{ needs.resolve-version.outputs.version }}
-          body_path: .github/release-body.md
+          body_path: ${{ steps.notes.outputs.path }}
+          prerelease: ${{ needs.resolve-version.outputs.is_prerelease == 'true' }}
           generate_release_notes: true
           files: |
             artifacts/windows-installer/*.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,7 +282,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/OpenAudible-BookOrganizer
+          # Spelled out in lower case rather than reusing the repository name: GHCR requires
+          # lower case, and leaving the folding implicit is what let the README document a
+          # pull command ("openaudible-book-organizer") that never matched what was published.
+          images: ghcr.io/${{ github.repository_owner }}/openaudible-bookorganizer
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           # A pre-release is published under its exact version only: 'latest' and the X.Y tag

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ riderModule.iml
 .dotnet
 .artifacts
 data
+
+# The Dockerfile copies the built frontend here during the image build; it is generated output,
+# and running the same copy locally to test the web UI should not show up as a change.
+ManagerApi/wwwroot/

--- a/AudioFileSorter.Tests/AudioFileSorter.Tests.csproj
+++ b/AudioFileSorter.Tests/AudioFileSorter.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AudioFileSorter\AudioFileSorter.csproj" />
+    <ProjectReference Include="..\ManagerApi\ManagerApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/AudioFileSorter.Tests/BookNamingTests.cs
+++ b/AudioFileSorter.Tests/BookNamingTests.cs
@@ -1,0 +1,111 @@
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter.Tests;
+
+public class BookNamingTests
+{
+    [Theory]
+    [InlineData("Brandon Sanderson", "Brandon Sanderson")]
+    [InlineData("Brandon Sanderson, Jane Doe", "Brandon Sanderson, Jane Doe")]
+    [InlineData("Brandon Sanderson, Brandon Sanderson", "Brandon Sanderson")]
+    [InlineData("Jane Doe - translator", "Unknown")]
+    [InlineData("Brandon Sanderson, Jane Doe - translator", "Brandon Sanderson")]
+    [InlineData("Brandon Sanderson, The Great Courses", "Brandon Sanderson")]
+    [InlineData("", "Unknown")]
+    [InlineData(null, "Unknown")]
+    [InlineData("Unknown", "Unknown")]
+    public void ResolveAuthor_strips_contributors_and_publisher_noise(string? input, string expected)
+    {
+        Assert.Equal(expected, BookNaming.ResolveAuthor(input));
+    }
+
+    [Fact]
+    public void ResolveAuthor_stays_within_the_segment_budget()
+    {
+        var manyAuthors = string.Join(", ", Enumerable.Range(0, 50).Select(i => $"Author Number {i}"));
+
+        var resolved = BookNaming.ResolveAuthor(manyAuthors);
+
+        Assert.True(resolved.Length <= PathSanitizer.MaxSegmentLength);
+    }
+
+    [Theory]
+    [InlineData("1", "1")]
+    [InlineData("Book 3", "3")]
+    [InlineData("book 3", "3")]
+    [InlineData("3.5", "3.5")]
+    [InlineData("2-3", "2-3")]
+    [InlineData("Volume 7 of the saga", "7")]
+    [InlineData("", null)]
+    [InlineData(null, null)]
+    [InlineData("N/A", null)]
+    [InlineData("no numbers here", null)]
+    public void ResolveSeriesSequence_extracts_the_numeric_part(string? input, string? expected)
+    {
+        Assert.Equal(expected, BookNaming.ResolveSeriesSequence(input));
+    }
+
+    [Fact]
+    public void BuildPlan_prefers_short_title_for_the_file_name()
+    {
+        var plan = BookNaming.BuildPlan(TempWorkspace.Book(title: "Long Title: A Story", shortTitle: "Long Title"));
+
+        Assert.Equal("Long Title", plan.FileStem);
+    }
+
+    [Fact]
+    public void BuildPlan_falls_back_to_the_title_when_there_is_no_short_title()
+    {
+        var plan = BookNaming.BuildPlan(TempWorkspace.Book(title: "Only Title", shortTitle: null));
+
+        Assert.Equal("Only Title", plan.FileStem);
+    }
+
+    [Fact]
+    public void BuildPlan_falls_back_to_the_source_file_name_before_giving_up()
+    {
+        // An export without Title or Short Title columns used to name every single book
+        // "Unknown", so each book overwrote the one before it.
+        var plan = BookNaming.BuildPlan(TempWorkspace.Book(title: null, shortTitle: null, filename: "the-hobbit"));
+
+        Assert.Equal("the-hobbit", plan.FileStem);
+    }
+
+    [Fact]
+    public void BuildPlan_drops_a_sequence_that_has_no_series()
+    {
+        var plan = BookNaming.BuildPlan(TempWorkspace.Book(seriesName: null, seriesSequence: "3"));
+
+        Assert.Null(plan.SeriesName);
+        Assert.Null(plan.SeriesSequence);
+    }
+
+    [Fact]
+    public void BuildPlan_does_not_modify_the_book_it_is_given()
+    {
+        // The parsed library is a shared singleton in the API; sorting must not rewrite it.
+        var book = TempWorkspace.Book(
+            title: "A Title: With Punctuation",
+            author: "Jane Doe, John Roe - translator",
+            seriesName: "The Series",
+            seriesSequence: "Book 2",
+            shortTitle: "A Title");
+
+        BookNaming.BuildPlan(book);
+
+        Assert.Equal("A Title: With Punctuation", book.Title);
+        Assert.Equal("Jane Doe, John Roe - translator", book.Author);
+        Assert.Equal("The Series", book.SeriesName);
+        Assert.Equal("Book 2", book.SeriesSequence);
+        Assert.Equal("A Title", book.ShortTitle);
+    }
+
+    [Fact]
+    public void BuildPlan_never_returns_an_empty_author_or_file_stem()
+    {
+        var plan = BookNaming.BuildPlan(new OpenAudible());
+
+        Assert.False(string.IsNullOrWhiteSpace(plan.Author));
+        Assert.False(string.IsNullOrWhiteSpace(plan.FileStem));
+    }
+}

--- a/AudioFileSorter.Tests/CsvParserTests.cs
+++ b/AudioFileSorter.Tests/CsvParserTests.cs
@@ -1,0 +1,212 @@
+using System.Text;
+
+namespace AudioFileSorter.Tests;
+
+public class CsvParserTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), "oabo-csv-tests", Guid.NewGuid().ToString("N"));
+
+    public CsvParserTests()
+    {
+        Directory.CreateDirectory(_directory);
+    }
+
+    [Fact]
+    public async Task Parses_a_standard_export()
+    {
+        var path = WriteCsv(
+            "Title,Author,File name,File Paths,Series Name,Series Sequence,Short Title,M4B",
+            "The Hobbit,J.R.R. Tolkien,the-hobbit,,Middle Earth,1,The Hobbit,Yes");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        var book = Assert.Single(result.Books);
+        Assert.Equal("The Hobbit", book.Title);
+        Assert.Equal("J.R.R. Tolkien", book.Author);
+        Assert.Equal("the-hobbit", book.Filename);
+        Assert.Equal("Middle Earth", book.SeriesName);
+        Assert.Equal(0, result.SkippedRows);
+    }
+
+    [Fact]
+    public async Task Parses_an_export_with_only_the_minimum_columns()
+    {
+        // Older exports and hand-trimmed files omit most columns; that used to throw a header
+        // validation error and lose the whole library.
+        var path = WriteCsv(
+            "Title,Author",
+            "The Hobbit,J.R.R. Tolkien");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        Assert.Single(result.Books);
+        Assert.Equal("The Hobbit", result.Books[0].Title);
+    }
+
+    [Fact]
+    public async Task Parses_an_export_with_empty_numeric_and_date_cells()
+    {
+        var path = WriteCsv(
+            "Title,Author,File name,Purchase Date,Release Date,Ave. Rating,Rating Count,AYCE",
+            "The Hobbit,Tolkien,the-hobbit,,,,,");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        var book = Assert.Single(result.Books);
+        Assert.Null(book.PurchaseDate);
+        Assert.Equal(0, book.AveRating);
+        Assert.Equal(0, book.RatingCount);
+        Assert.False(book.AYCE);
+    }
+
+    [Fact]
+    public async Task Parses_an_export_with_unparseable_numeric_and_date_cells()
+    {
+        var path = WriteCsv(
+            "Title,Author,File name,Purchase Date,Ave. Rating,Rating Count",
+            "The Hobbit,Tolkien,the-hobbit,not-a-date,not-a-number,lots");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        var book = Assert.Single(result.Books);
+        Assert.Null(book.PurchaseDate);
+        Assert.Equal(0, book.AveRating);
+        Assert.Equal(0, book.RatingCount);
+    }
+
+    [Theory]
+    [InlineData("2020-05-04")]
+    [InlineData("05/04/2020")]
+    [InlineData("5/4/2020")]
+    public async Task Accepts_the_date_formats_openaudible_has_shipped(string date)
+    {
+        var path = WriteCsv(
+            "Title,Author,File name,Purchase Date",
+            $"The Hobbit,Tolkien,the-hobbit,{date}");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        Assert.NotNull(Assert.Single(result.Books).PurchaseDate);
+    }
+
+    [Fact]
+    public async Task Keeps_the_good_rows_when_one_row_is_short()
+    {
+        var path = WriteCsv(
+            "Title,Author,File name,Series Name",
+            "Book One,Author One,book-one,Series",
+            "Book Two,Author Two",
+            "Book Three,Author Three,book-three,Series");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        Assert.Equal(3, result.Books.Count);
+        Assert.Equal("Book Two", result.Books[1].Title);
+    }
+
+    [Fact]
+    public async Task Reads_a_tab_separated_export()
+    {
+        var path = WriteCsv(
+            "Title\tAuthor\tFile name",
+            "The Hobbit\tTolkien\tthe-hobbit");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        Assert.Equal("The Hobbit", Assert.Single(result.Books).Title);
+    }
+
+    [Fact]
+    public async Task Reads_a_file_that_starts_with_a_utf8_byte_order_mark()
+    {
+        var path = Path.Combine(_directory, "bom.csv");
+        await File.WriteAllTextAsync(
+            path,
+            "Title,Author,File name\nThe Hobbit,Tolkien,the-hobbit\n",
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        Assert.Equal("The Hobbit", Assert.Single(result.Books).Title);
+    }
+
+    [Fact]
+    public async Task Reads_quoted_fields_that_span_lines()
+    {
+        var path = WriteCsv(
+            "Title,Author,File name,Summary",
+            "\"The Hobbit\",Tolkien,the-hobbit,\"A long\nsummary, with a comma\"");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        var book = Assert.Single(result.Books);
+        Assert.Equal("The Hobbit", book.Title);
+        Assert.Contains("with a comma", book.Summary);
+    }
+
+    [Fact]
+    public async Task Returns_an_empty_library_for_a_header_only_export()
+    {
+        var path = WriteCsv("Title,Author,File name");
+
+        var result = await new CsvParser().ParseAsync(path, CancellationToken.None);
+
+        Assert.Empty(result.Books);
+    }
+
+    [Fact]
+    public async Task Rejects_a_file_that_is_not_an_openaudible_export()
+    {
+        var path = WriteCsv("alpha,beta,gamma", "1,2,3");
+
+        var exception = await Assert.ThrowsAsync<InvalidDataException>(
+            () => new CsvParser().ParseAsync(path, CancellationToken.None));
+
+        Assert.Contains("does not look like an OpenAudible export", exception.Message);
+    }
+
+    [Fact]
+    public async Task Rejects_an_empty_file_with_a_clear_message()
+    {
+        var path = WriteCsv();
+
+        await Assert.ThrowsAsync<InvalidDataException>(
+            () => new CsvParser().ParseAsync(path, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Reports_a_missing_file_as_a_missing_file()
+    {
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => new CsvParser().ParseAsync(Path.Combine(_directory, "nope.csv"), CancellationToken.None));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    public async Task Reports_a_missing_path_as_an_argument_error(string? path)
+    {
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            () => new CsvParser().ParseAsync(path, CancellationToken.None));
+    }
+
+    private string WriteCsv(params string[] lines)
+    {
+        var path = Path.Combine(_directory, $"{Guid.NewGuid():N}.csv");
+        File.WriteAllText(path, string.Join("\n", lines) + (lines.Length > 0 ? "\n" : string.Empty));
+        return path;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Temp folder cleanup is best effort.
+        }
+    }
+}

--- a/AudioFileSorter.Tests/FileSorterTests.cs
+++ b/AudioFileSorter.Tests/FileSorterTests.cs
@@ -173,7 +173,7 @@ public class FileSorterTests
         var reports = new List<SortProgressInfo>();
 
         var summary = await new FileSorter().SortAudioFiles(
-            workspace.Source, workspace.Destination, [], new Progress<SortProgressInfo>(reports.Add));
+            workspace.Source, workspace.Destination, [], progress: new Progress<SortProgressInfo>(reports.Add));
 
         Assert.Equal(0, summary.TotalBooks);
         await WaitForAsync(() => reports.Any(r => r.IsComplete));
@@ -299,7 +299,7 @@ public class FileSorterTests
 
     private static Task<SortSummary> Sort(TempWorkspace workspace, IProgress<SortProgressInfo>? progress, params OpenAudible[] books)
     {
-        return new FileSorter().SortAudioFiles(workspace.Source, workspace.Destination, [.. books], progress);
+        return new FileSorter().SortAudioFiles(workspace.Source, workspace.Destination, [.. books], progress: progress);
     }
 
     /// <summary>

--- a/AudioFileSorter.Tests/FileSorterTests.cs
+++ b/AudioFileSorter.Tests/FileSorterTests.cs
@@ -1,0 +1,324 @@
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter.Tests;
+
+public class FileSorterTests
+{
+    [Fact]
+    public async Task Sort_copies_a_book_into_the_author_folder()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b", "audio-bytes");
+
+        var summary = await Sort(workspace, TempWorkspace.Book());
+
+        Assert.Equal(["An Author/A Book.m4b"], workspace.DestinationFiles());
+        Assert.Equal(1, summary.CopiedBooks);
+        Assert.Equal(0, summary.FailedBooks);
+        Assert.Equal("audio-bytes", File.ReadAllText(Path.Combine(workspace.Destination, "An Author", "A Book.m4b")));
+    }
+
+    [Fact]
+    public async Task Sort_copies_a_series_book_into_the_documented_folder_structure()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("sorcerers-stone.m4b");
+
+        await Sort(workspace, TempWorkspace.Book(
+            author: "J.K. Rowling",
+            title: "Harry Potter and the Sorcerer's Stone",
+            filename: "sorcerers-stone",
+            seriesName: "Wizarding World",
+            seriesSequence: "1"));
+
+        Assert.Equal(
+            ["J.K. Rowling/Wizarding World/Book 1/Harry Potter and the Sorcerer's Stone.m4b"],
+            workspace.DestinationFiles());
+    }
+
+    [Fact]
+    public async Task Sort_copies_the_companion_pdf_next_to_the_audio_file()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        workspace.WriteSourceFile("a-book.pdf", "pdf-bytes");
+
+        await Sort(workspace, TempWorkspace.Book());
+
+        Assert.Equal(["An Author/A Book.m4b", "An Author/A Book.pdf"], workspace.DestinationFiles());
+    }
+
+    [Fact]
+    public async Task Sort_leaves_the_parsed_library_untouched()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        var book = TempWorkspace.Book(author: "Jane Doe, John Roe - editor", title: "A Book: Subtitle", shortTitle: "A Book");
+
+        await Sort(workspace, book);
+
+        Assert.Equal("Jane Doe, John Roe - editor", book.Author);
+        Assert.Equal("A Book: Subtitle", book.Title);
+    }
+
+    [Fact]
+    public async Task Sort_is_idempotent_and_copies_nothing_on_a_second_run()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b", new string('x', 20_000));
+
+        var first = await Sort(workspace, TempWorkspace.Book());
+        var second = await Sort(workspace, TempWorkspace.Book());
+
+        Assert.Equal(1, first.CopiedBooks);
+        Assert.Equal(0, second.CopiedBooks);
+        Assert.Equal(1, second.SkippedBooks);
+        Assert.Single(workspace.DestinationFiles());
+    }
+
+    [Fact]
+    public async Task Sort_replaces_a_destination_file_whose_contents_changed()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b", "new-audio");
+        workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), "old-audio!");
+
+        var summary = await Sort(workspace, TempWorkspace.Book());
+
+        Assert.Equal(1, summary.CopiedBooks);
+        Assert.Equal("new-audio", File.ReadAllText(Path.Combine(workspace.Destination, "An Author", "A Book.m4b")));
+    }
+
+    [Fact]
+    public async Task Sort_does_not_create_folders_for_books_with_no_files()
+    {
+        using var workspace = new TempWorkspace();
+
+        var summary = await Sort(workspace, TempWorkspace.Book());
+
+        Assert.Empty(workspace.DestinationDirectories());
+        Assert.Equal(0, summary.CopiedBooks);
+        Assert.Equal(1, summary.SkippedBooks);
+        Assert.Equal(1, summary.WarningCount);
+    }
+
+    [Fact]
+    public async Task Sort_keeps_going_when_one_book_cannot_be_written()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("good.m4b");
+        workspace.WriteSourceFile("blocked.m4b");
+
+        // A folder sitting where the file should go makes the copy fail for that book only.
+        Directory.CreateDirectory(Path.Combine(workspace.Destination, "An Author", "Blocked Book.m4b"));
+
+        var summary = await Sort(
+            workspace,
+            TempWorkspace.Book(title: "Good Book", filename: "good"),
+            TempWorkspace.Book(title: "Blocked Book", filename: "blocked"));
+
+        Assert.Equal(2, summary.TotalBooks);
+        Assert.Equal(1, summary.CopiedBooks);
+        Assert.Equal(1, summary.FailedBooks);
+        Assert.Contains("An Author/Good Book.m4b", workspace.DestinationFiles());
+        Assert.Contains(summary.Warnings, warning => warning.Contains("blocked", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Sort_leaves_no_partial_file_behind_when_a_copy_fails()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("blocked.m4b");
+        Directory.CreateDirectory(Path.Combine(workspace.Destination, "An Author", "Blocked Book.m4b"));
+
+        await Sort(workspace, TempWorkspace.Book(title: "Blocked Book", filename: "blocked"));
+
+        Assert.DoesNotContain(workspace.DestinationFiles(), file => file.Contains(".oabo-partial"));
+    }
+
+    [Fact]
+    public async Task Sort_writes_no_partial_file_when_cancelled()
+    {
+        using var workspace = new TempWorkspace();
+        for (var i = 0; i < 200; i++)
+        {
+            workspace.WriteSourceFile($"book-{i}.m4b", new string('x', 200_000));
+        }
+
+        var books = Enumerable.Range(0, 200)
+            .Select(i => TempWorkspace.Book(title: $"Book {i}", filename: $"book-{i}"))
+            .ToList();
+
+        using var cancellation = new CancellationTokenSource();
+        var sortTask = new FileSorter().SortAudioFiles(
+            workspace.Source, workspace.Destination, books, cancellationToken: cancellation.Token);
+
+        cancellation.CancelAfter(TimeSpan.FromMilliseconds(30));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await sortTask);
+
+        Assert.DoesNotContain(workspace.DestinationFiles(), file => file.Contains(".oabo-partial"));
+
+        // Everything that did land must be complete, not truncated.
+        foreach (var file in Directory.GetFiles(workspace.Destination, "*.m4b", SearchOption.AllDirectories))
+        {
+            Assert.Equal(200_000, new FileInfo(file).Length);
+        }
+    }
+
+    [Fact]
+    public async Task Sort_reports_completion_for_an_empty_library()
+    {
+        using var workspace = new TempWorkspace();
+        var reports = new List<SortProgressInfo>();
+
+        var summary = await new FileSorter().SortAudioFiles(
+            workspace.Source, workspace.Destination, [], new Progress<SortProgressInfo>(reports.Add));
+
+        Assert.Equal(0, summary.TotalBooks);
+        await WaitForAsync(() => reports.Any(r => r.IsComplete));
+        Assert.All(reports, report => Assert.False(double.IsNaN(report.Percentage)));
+    }
+
+    [Fact]
+    public async Task Sort_rejects_a_missing_source_folder_instead_of_silently_doing_nothing()
+    {
+        using var workspace = new TempWorkspace();
+
+        await Assert.ThrowsAsync<DirectoryNotFoundException>(() => new FileSorter().SortAudioFiles(
+            Path.Combine(workspace.Root, "does-not-exist"), workspace.Destination, [TempWorkspace.Book()]));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Sort_rejects_a_missing_path(string? path)
+    {
+        using var workspace = new TempWorkspace();
+
+        await Assert.ThrowsAsync<ArgumentException>(() => new FileSorter().SortAudioFiles(
+            path, workspace.Destination, [TempWorkspace.Book()]));
+
+        await Assert.ThrowsAsync<ArgumentException>(() => new FileSorter().SortAudioFiles(
+            workspace.Source, path, [TempWorkspace.Book()]));
+    }
+
+    [Fact]
+    public async Task Sort_creates_the_destination_folder_when_it_does_not_exist_yet()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        var destination = Path.Combine(workspace.Root, "new-destination");
+
+        await new FileSorter().SortAudioFiles(workspace.Source, destination, [TempWorkspace.Book()]);
+
+        Assert.True(File.Exists(Path.Combine(destination, "An Author", "A Book.m4b")));
+    }
+
+    [Fact]
+    public async Task Sort_never_writes_outside_the_destination_folder()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        var escapeTarget = Path.Combine(workspace.Root, "escaped.m4b");
+
+        await Sort(workspace, TempWorkspace.Book(author: "..", title: "..\\..\\escaped", seriesName: ".."));
+
+        Assert.False(File.Exists(escapeTarget));
+        Assert.All(
+            Directory.GetFiles(workspace.Root, "*", SearchOption.AllDirectories),
+            file => Assert.True(
+                file.StartsWith(workspace.Source, StringComparison.Ordinal) ||
+                file.StartsWith(workspace.Destination, StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public async Task Sort_reports_progress_that_ends_at_one_hundred_percent()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        var reports = new List<SortProgressInfo>();
+
+        await Sort(workspace, new Progress<SortProgressInfo>(report =>
+        {
+            lock (reports)
+            {
+                reports.Add(report);
+            }
+        }), TempWorkspace.Book());
+
+        await WaitForAsync(() =>
+        {
+            lock (reports)
+            {
+                return reports.Any(r => r.IsComplete);
+            }
+        });
+
+        lock (reports)
+        {
+            Assert.All(reports, report => Assert.InRange(report.Percentage, 0, 100));
+            Assert.Equal(100, reports.Last(r => r.IsComplete).Percentage);
+        }
+    }
+
+    [Fact]
+    public async Task Sort_handles_a_large_library_across_many_authors_without_duplicating_folders()
+    {
+        using var workspace = new TempWorkspace();
+        var books = new List<OpenAudible>();
+
+        for (var i = 0; i < 120; i++)
+        {
+            workspace.WriteSourceFile($"book-{i}.m4b", $"content-{i}");
+            books.Add(TempWorkspace.Book(
+                // Alternating spellings of the same three authors.
+                author: (i % 3) switch
+                {
+                    0 => i % 2 == 0 ? "J.K. Rowling" : "JK Rowling",
+                    1 => i % 2 == 0 ? "Brandon Sanderson" : "Brandon  Sanderson",
+                    _ => "Terry Pratchett"
+                },
+                title: $"Book {i}",
+                filename: $"book-{i}"));
+        }
+
+        var summary = await new FileSorter().SortAudioFiles(workspace.Source, workspace.Destination, books);
+
+        Assert.Equal(120, summary.CopiedBooks);
+        Assert.Equal(0, summary.FailedBooks);
+        Assert.Equal(3, Directory.GetDirectories(workspace.Destination).Length);
+        Assert.Equal(120, workspace.DestinationFiles().Length);
+    }
+
+    private static Task<SortSummary> Sort(TempWorkspace workspace, params OpenAudible[] books)
+    {
+        return Sort(workspace, null, books);
+    }
+
+    private static Task<SortSummary> Sort(TempWorkspace workspace, IProgress<SortProgressInfo>? progress, params OpenAudible[] books)
+    {
+        return new FileSorter().SortAudioFiles(workspace.Source, workspace.Destination, [.. books], progress);
+    }
+
+    /// <summary>
+    /// <see cref="Progress{T}"/> dispatches on the thread pool, so the last report can arrive
+    /// just after the sort returns.
+    /// </summary>
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMilliseconds = 5000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMilliseconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.Fail("Timed out waiting for the expected progress report.");
+    }
+}

--- a/AudioFileSorter.Tests/PathSanitizerTests.cs
+++ b/AudioFileSorter.Tests/PathSanitizerTests.cs
@@ -1,0 +1,168 @@
+namespace AudioFileSorter.Tests;
+
+public class PathSanitizerTests
+{
+    [Theory]
+    [InlineData("Harry Potter", "Harry Potter")]
+    [InlineData("  Harry   Potter  ", "Harry Potter")]
+    [InlineData("Book: The Sequel", "Book The Sequel")]
+    [InlineData("What?", "What")]
+    [InlineData("A/B", "AB")]
+    [InlineData("A\\B", "AB")]
+    [InlineData("Star * Wars", "Star Wars")]
+    [InlineData("Quote\"Test", "QuoteTest")]
+    [InlineData("Pipe|Test", "PipeTest")]
+    [InlineData("Trailing dots...", "Trailing dots")]
+    [InlineData("Trailing space   ", "Trailing space")]
+    public void SanitizeSegment_removes_characters_that_are_invalid_on_any_supported_platform(string input, string expected)
+    {
+        Assert.Equal(expected, PathSanitizer.SanitizeSegment(input));
+    }
+
+    [Theory]
+    [InlineData("Line\nBreak", "Line Break")]
+    [InlineData("Tab\tSeparated", "Tab Separated")]
+    public void SanitizeSegment_turns_control_characters_into_a_single_space(string input, string expected)
+    {
+        Assert.Equal(expected, PathSanitizer.SanitizeSegment(input));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("unknown")]
+    [InlineData("Unknown")]
+    [InlineData("N/A")]
+    [InlineData("none")]
+    [InlineData("null")]
+    [InlineData("...")]
+    [InlineData("///")]
+    public void SanitizeSegment_returns_null_for_values_that_carry_no_information(string? input)
+    {
+        Assert.Null(PathSanitizer.SanitizeSegment(input));
+    }
+
+    [Theory]
+    [InlineData("..")]
+    [InlineData(".")]
+    [InlineData("../..")]
+    [InlineData("..\\..")]
+    [InlineData("/etc/passwd")]
+    [InlineData("C:\\Windows\\System32")]
+    public void SanitizeSegment_never_produces_a_traversal_segment(string input)
+    {
+        var sanitized = PathSanitizer.SanitizeSegment(input);
+
+        Assert.True(sanitized is null || (sanitized != ".." && sanitized != "." && !sanitized.Contains('/') && !sanitized.Contains('\\')));
+    }
+
+    [Theory]
+    [InlineData("CON")]
+    [InlineData("con")]
+    [InlineData("NUL")]
+    [InlineData("COM1")]
+    [InlineData("LPT9")]
+    [InlineData("aux.txt")]
+    public void SanitizeSegment_escapes_reserved_windows_device_names(string input)
+    {
+        var sanitized = PathSanitizer.SanitizeSegment(input);
+
+        Assert.NotNull(sanitized);
+        Assert.StartsWith("_", sanitized);
+    }
+
+    [Fact]
+    public void SanitizeSegment_keeps_ordinary_names_that_merely_start_with_a_device_name()
+    {
+        Assert.Equal("Conan the Barbarian", PathSanitizer.SanitizeSegment("Conan the Barbarian"));
+    }
+
+    [Fact]
+    public void SanitizeSegment_truncates_a_name_that_would_be_rejected_by_the_filesystem()
+    {
+        var sanitized = PathSanitizer.SanitizeSegment(new string('a', 500));
+
+        Assert.NotNull(sanitized);
+        Assert.Equal(PathSanitizer.MaxSegmentLength, sanitized!.Length);
+    }
+
+    [Fact]
+    public void SanitizeSegment_respects_the_byte_budget_for_multi_byte_names()
+    {
+        // Each of these characters is three bytes in UTF-8.
+        var sanitized = PathSanitizer.SanitizeSegment(new string('あ', 300));
+
+        Assert.NotNull(sanitized);
+        Assert.True(System.Text.Encoding.UTF8.GetByteCount(sanitized!) <= PathSanitizer.MaxSegmentBytes);
+    }
+
+    [Fact]
+    public void SanitizeSegment_does_not_split_a_surrogate_pair()
+    {
+        var emoji = string.Concat(Enumerable.Repeat("😀", 200));
+
+        var sanitized = PathSanitizer.SanitizeSegment(emoji);
+
+        Assert.NotNull(sanitized);
+        Assert.False(char.IsHighSurrogate(sanitized![^1]));
+    }
+
+    [Theory]
+    [InlineData("J.K. Rowling", "JK Rowling")]
+    [InlineData("J K Rowling", "jkrowling")]
+    [InlineData("Brandon  Sanderson", "brandonsanderson")]
+    public void NormalizeComparisonKey_ignores_punctuation_and_case(string first, string second)
+    {
+        Assert.Equal(PathSanitizer.NormalizeComparisonKey(first), PathSanitizer.NormalizeComparisonKey(second));
+    }
+
+    [Theory]
+    [InlineData("The Wheel of Time", "Wheel of Time")]
+    [InlineData("The Wheel of Time", "Wheel of Time Series")]
+    [InlineData("A Song of Ice and Fire", "Song of Ice and Fire Saga")]
+    public void NormalizeSeriesKey_ignores_articles_and_decorators(string first, string second)
+    {
+        Assert.Equal(PathSanitizer.NormalizeSeriesKey(first), PathSanitizer.NormalizeSeriesKey(second));
+    }
+
+    [Fact]
+    public void NormalizeSeriesKey_keeps_distinct_series_distinct()
+    {
+        Assert.NotEqual(PathSanitizer.NormalizeSeriesKey("Mistborn"), PathSanitizer.NormalizeSeriesKey("Stormlight"));
+    }
+
+    [Fact]
+    public void IsWithin_accepts_a_path_inside_the_root()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "oabo-root");
+
+        Assert.True(PathSanitizer.IsWithin(root, Path.Combine(root, "Author", "Book.m4b")));
+    }
+
+    [Theory]
+    [InlineData("..")]
+    [InlineData("../sibling")]
+    public void IsWithin_rejects_a_path_that_escapes_the_root(string relative)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "oabo-root");
+
+        Assert.False(PathSanitizer.IsWithin(root, Path.Combine(root, relative)));
+    }
+
+    [Fact]
+    public void IsWithin_rejects_the_root_itself()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "oabo-root");
+
+        Assert.False(PathSanitizer.IsWithin(root, root));
+    }
+
+    [Fact]
+    public void IsWithin_rejects_a_sibling_with_the_same_prefix()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "library");
+
+        Assert.False(PathSanitizer.IsWithin(root, Path.Combine(Path.GetTempPath(), "library-backup", "book.m4b")));
+    }
+}

--- a/AudioFileSorter.Tests/SortPlannerTests.cs
+++ b/AudioFileSorter.Tests/SortPlannerTests.cs
@@ -181,6 +181,40 @@ public class SortPlannerTests
     }
 
     [Fact]
+    public void Plan_falls_back_to_the_source_folder_when_a_recorded_absolute_path_is_stale()
+    {
+        // Exports record where the file was, which is routinely not where it is now: another
+        // machine, another drive, a restored backup.
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        var stalePath = Path.Combine(Path.GetTempPath(), "oabo-not-here", "a-book.m4b");
+        Assert.True(Path.IsPathRooted(stalePath));
+
+        var planned = Plan(
+            workspace,
+            TempWorkspace.Book(m4b: null, filename: "not-this-one", filePaths: stalePath));
+
+        Assert.Equal(Path.Combine(workspace.Destination, "An Author", "A Book.m4b"), planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_prefers_a_recorded_absolute_path_that_still_exists()
+    {
+        using var workspace = new TempWorkspace();
+        var elsewhere = Path.Combine(workspace.Root, "elsewhere");
+        Directory.CreateDirectory(elsewhere);
+        var recordedPath = Path.Combine(elsewhere, "a-book.m4b");
+        File.WriteAllText(recordedPath, "recorded");
+        workspace.WriteSourceFile("a-book.m4b", "in-source");
+
+        var planned = Plan(
+            workspace,
+            TempWorkspace.Book(m4b: null, filename: "not-this-one", filePaths: recordedPath));
+
+        Assert.Equal(recordedPath, planned[0].AudioSource);
+    }
+
+    [Fact]
     public void Plan_is_deterministic_for_the_same_input()
     {
         using var workspace = new TempWorkspace();

--- a/AudioFileSorter.Tests/SortPlannerTests.cs
+++ b/AudioFileSorter.Tests/SortPlannerTests.cs
@@ -107,13 +107,16 @@ public class SortPlannerTests
     {
         using var workspace = new TempWorkspace();
         workspace.WriteSourceFile("a-book.m4b");
-        // Written by an older version, before ':' was stripped on Linux.
-        workspace.WriteDestinationFile(Path.Combine("An Author", "A Book: The Sequel.m4b"), "audio");
+        // Written by an earlier version that punctuated the name differently. The fixture name
+        // has to be legal on every platform: NTFS reads ':' as an alternate data stream.
+        workspace.WriteDestinationFile(Path.Combine("An Author", "A Book - The Sequel.m4b"), "audio");
 
         var planned = Plan(workspace, TempWorkspace.Book(title: "A Book: The Sequel"));
 
+        // Sanitising gives "A Book The Sequel", but the existing file means the same thing, so it
+        // is reused rather than duplicated alongside it.
         Assert.Equal(
-            Path.Combine(workspace.Destination, "An Author", "A Book: The Sequel.m4b"),
+            Path.Combine(workspace.Destination, "An Author", "A Book - The Sequel.m4b"),
             planned[0].AudioDestination);
     }
 

--- a/AudioFileSorter.Tests/SortPlannerTests.cs
+++ b/AudioFileSorter.Tests/SortPlannerTests.cs
@@ -1,0 +1,205 @@
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter.Tests;
+
+public class SortPlannerTests
+{
+    [Fact]
+    public void Plan_places_a_standalone_book_under_the_author()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+
+        var planned = Plan(workspace, TempWorkspace.Book());
+
+        Assert.Equal(Path.Combine(workspace.Destination, "An Author", "A Book.m4b"), planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_places_a_series_book_under_author_series_and_book_number()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+
+        var planned = Plan(workspace, TempWorkspace.Book(seriesName: "The Series", seriesSequence: "Book 2"));
+
+        Assert.Equal(
+            Path.Combine(workspace.Destination, "An Author", "The Series", "Book 2", "A Book.m4b"),
+            planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_reuses_an_existing_author_folder_that_is_spelled_differently()
+    {
+        using var workspace = new TempWorkspace();
+        Directory.CreateDirectory(Path.Combine(workspace.Destination, "JK Rowling"));
+        workspace.WriteSourceFile("a-book.m4b");
+
+        var planned = Plan(workspace, TempWorkspace.Book(author: "J.K. Rowling"));
+
+        Assert.Equal(
+            Path.Combine(workspace.Destination, "JK Rowling", "A Book.m4b"),
+            planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_files_differently_spelled_authors_into_one_folder_within_a_run()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("book-one.m4b");
+        workspace.WriteSourceFile("book-two.m4b");
+
+        var planned = Plan(
+            workspace,
+            TempWorkspace.Book(author: "J.K. Rowling", title: "Book One", filename: "book-one"),
+            TempWorkspace.Book(author: "JK Rowling", title: "Book Two", filename: "book-two"));
+
+        Assert.Equal(
+            Path.GetDirectoryName(planned[0].AudioDestination),
+            Path.GetDirectoryName(planned[1].AudioDestination));
+    }
+
+    [Fact]
+    public void Plan_reuses_an_existing_series_folder_that_is_spelled_differently()
+    {
+        using var workspace = new TempWorkspace();
+        Directory.CreateDirectory(Path.Combine(workspace.Destination, "An Author", "Wheel of Time"));
+        workspace.WriteSourceFile("a-book.m4b");
+
+        var planned = Plan(workspace, TempWorkspace.Book(seriesName: "The Wheel of Time Series"));
+
+        Assert.Equal(
+            Path.Combine(workspace.Destination, "An Author", "Wheel of Time", "A Book.m4b"),
+            planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_gives_two_different_books_with_the_same_name_separate_files()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("first.m4b");
+        workspace.WriteSourceFile("second.m4b");
+
+        var planned = Plan(
+            workspace,
+            TempWorkspace.Book(title: "Collected Works", filename: "first"),
+            TempWorkspace.Book(title: "Collected Works", filename: "second"));
+
+        Assert.NotEqual(planned[0].AudioDestination, planned[1].AudioDestination);
+        Assert.Equal(Path.Combine(workspace.Destination, "An Author", "Collected Works.m4b"), planned[0].AudioDestination);
+        Assert.Equal(Path.Combine(workspace.Destination, "An Author", "Collected Works (2).m4b"), planned[1].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_copies_a_duplicated_row_only_once()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+
+        var planned = Plan(workspace, TempWorkspace.Book(), TempWorkspace.Book());
+
+        Assert.NotNull(planned[0].AudioDestination);
+        Assert.Null(planned[1].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_reuses_a_destination_file_that_already_exists_under_an_equivalent_name()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        // Written by an older version, before ':' was stripped on Linux.
+        workspace.WriteDestinationFile(Path.Combine("An Author", "A Book: The Sequel.m4b"), "audio");
+
+        var planned = Plan(workspace, TempWorkspace.Book(title: "A Book: The Sequel"));
+
+        Assert.Equal(
+            Path.Combine(workspace.Destination, "An Author", "A Book: The Sequel.m4b"),
+            planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_keeps_a_traversal_attempt_inside_the_destination()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+
+        var planned = Plan(workspace, TempWorkspace.Book(author: "../../etc", title: "../../passwd"));
+
+        Assert.NotNull(planned[0].AudioDestination);
+        Assert.True(PathSanitizer.IsWithin(workspace.Destination, planned[0].AudioDestination!));
+    }
+
+    [Fact]
+    public void Plan_reports_a_book_whose_files_are_missing_instead_of_failing()
+    {
+        using var workspace = new TempWorkspace();
+
+        var planned = Plan(workspace, TempWorkspace.Book());
+
+        Assert.False(planned[0].HasWork);
+        Assert.NotNull(planned[0].Warning);
+        Assert.Null(planned[0].TargetDirectory);
+    }
+
+    [Fact]
+    public void Plan_finds_a_pdf_companion_named_after_the_book()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+        workspace.WriteSourceFile("a-book.pdf", "pdf");
+
+        var planned = Plan(workspace, TempWorkspace.Book());
+
+        Assert.Equal(Path.Combine(workspace.Destination, "An Author", "A Book.pdf"), planned[0].PdfDestination);
+    }
+
+    [Fact]
+    public void Plan_finds_an_audio_file_even_when_the_format_columns_are_empty()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.mp3");
+
+        var planned = Plan(workspace, TempWorkspace.Book(m4b: null, mp3: null));
+
+        Assert.Equal(Path.Combine(workspace.Destination, "An Author", "A Book.mp3"), planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_finds_an_audio_file_listed_with_a_windows_style_path()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b");
+
+        var planned = Plan(
+            workspace,
+            TempWorkspace.Book(m4b: null, filename: "not-this-one", filePaths: @"C:\OpenAudible\books\a-book.m4b"));
+
+        Assert.Equal(Path.Combine(workspace.Destination, "An Author", "A Book.m4b"), planned[0].AudioDestination);
+    }
+
+    [Fact]
+    public void Plan_is_deterministic_for_the_same_input()
+    {
+        using var workspace = new TempWorkspace();
+        for (var i = 0; i < 20; i++)
+        {
+            workspace.WriteSourceFile($"book-{i}.m4b");
+        }
+
+        var books = Enumerable.Range(0, 20)
+            .Select(i => TempWorkspace.Book(title: "Same Title", author: i % 2 == 0 ? "A. Author" : "A Author", filename: $"book-{i}"))
+            .ToList();
+
+        var first = new SortPlanner().Plan(books, workspace.Source, workspace.Destination);
+        var second = new SortPlanner().Plan(books, workspace.Source, workspace.Destination);
+
+        Assert.Equal(
+            first.Select(p => p.AudioDestination),
+            second.Select(p => p.AudioDestination));
+    }
+
+    private static List<PlannedCopy> Plan(TempWorkspace workspace, params OpenAudible[] books)
+    {
+        return new SortPlanner().Plan(books, workspace.Source, workspace.Destination);
+    }
+}

--- a/AudioFileSorter.Tests/SortServiceTests.cs
+++ b/AudioFileSorter.Tests/SortServiceTests.cs
@@ -1,0 +1,176 @@
+using ManagerApi.Services;
+
+namespace AudioFileSorter.Tests;
+
+public class SortServiceTests
+{
+    [Fact]
+    public async Task TryStartSort_runs_a_sort_and_reports_completion()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("the-hobbit.m4b");
+        var csvPath = WriteCsv(workspace, "The Hobbit,Tolkien,the-hobbit");
+
+        var service = new SortService();
+
+        Assert.True(service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out var sortTask));
+        await sortTask;
+
+        var progress = service.GetProgress();
+        Assert.True(progress.IsComplete);
+        Assert.Null(progress.Error);
+        Assert.Equal(1, progress.CopiedBooks);
+        Assert.False(service.IsSorting);
+        Assert.Equal(["Tolkien/The Hobbit.m4b"], workspace.DestinationFiles());
+    }
+
+    [Fact]
+    public async Task TryStartSort_refuses_a_second_concurrent_run()
+    {
+        using var workspace = new TempWorkspace();
+        for (var i = 0; i < 60; i++)
+        {
+            workspace.WriteSourceFile($"book-{i}.m4b", new string('x', 300_000));
+        }
+
+        var csvPath = WriteCsv(
+            workspace,
+            Enumerable.Range(0, 60).Select(i => $"Book {i},Author,book-{i}").ToArray());
+
+        var service = new SortService();
+        Assert.True(service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out var first));
+
+        var startedAgain = service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out _);
+
+        await first;
+        Assert.False(startedAgain);
+    }
+
+    [Fact]
+    public async Task Parallel_start_attempts_only_ever_start_one_run()
+    {
+        using var workspace = new TempWorkspace();
+        for (var i = 0; i < 40; i++)
+        {
+            workspace.WriteSourceFile($"book-{i}.m4b", new string('x', 200_000));
+        }
+
+        var csvPath = WriteCsv(
+            workspace,
+            Enumerable.Range(0, 40).Select(i => $"Book {i},Author,book-{i}").ToArray());
+
+        var service = new SortService();
+        var started = 0;
+        var tasks = new List<Task>();
+
+        Parallel.For(0, 8, _ =>
+        {
+            if (service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out var task))
+            {
+                Interlocked.Increment(ref started);
+                lock (tasks)
+                {
+                    tasks.Add(task);
+                }
+            }
+        });
+
+        await Task.WhenAll(tasks);
+        Assert.Equal(1, started);
+    }
+
+    [Fact]
+    public async Task CancelSort_stops_a_running_sort_and_records_it()
+    {
+        using var workspace = new TempWorkspace();
+        for (var i = 0; i < 200; i++)
+        {
+            workspace.WriteSourceFile($"book-{i}.m4b", new string('x', 300_000));
+        }
+
+        var csvPath = WriteCsv(
+            workspace,
+            Enumerable.Range(0, 200).Select(i => $"Book {i},Author,book-{i}").ToArray());
+
+        var service = new SortService();
+        Assert.True(service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out var sortTask));
+
+        // Wait until the run is actually under way before cancelling it.
+        var deadline = DateTime.UtcNow.AddSeconds(10);
+        while (service.GetProgress().CurrentBook == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(service.CancelSort());
+        await sortTask;
+
+        var progress = service.GetProgress();
+        Assert.True(progress.IsComplete);
+        Assert.True(progress.IsCanceled);
+        Assert.False(service.IsSorting);
+    }
+
+    [Fact]
+    public void CancelSort_returns_false_when_nothing_is_running()
+    {
+        Assert.False(new SortService().CancelSort());
+    }
+
+    [Fact]
+    public async Task A_failing_sort_reports_the_error_instead_of_hanging()
+    {
+        using var workspace = new TempWorkspace();
+        var csvPath = WriteCsv(workspace, "The Hobbit,Tolkien,the-hobbit");
+
+        var service = new SortService();
+        Assert.True(service.TryStartSort(csvPath, Path.Combine(workspace.Root, "missing"), workspace.Destination, out var sortTask));
+        await sortTask;
+
+        var progress = service.GetProgress();
+        Assert.True(progress.IsComplete);
+        Assert.False(string.IsNullOrWhiteSpace(progress.Error));
+        Assert.False(service.IsSorting);
+    }
+
+    [Fact]
+    public async Task ParseBooks_reloads_when_the_csv_path_changes()
+    {
+        using var workspace = new TempWorkspace();
+        var firstCsv = WriteCsv(workspace, "Book One,Author,book-one");
+        var secondCsv = WriteCsv(workspace, "Book Two,Author,book-two");
+
+        var service = new SortService();
+        await service.ParseBooks(firstCsv);
+        Assert.Equal("Book One", service.GetBooks()[0].Title);
+
+        await service.ParseBooks(secondCsv);
+        Assert.Equal("Book Two", service.GetBooks()[0].Title);
+    }
+
+    [Fact]
+    public async Task Sorting_a_different_csv_than_the_loaded_one_uses_the_requested_file()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("book-one.m4b");
+        workspace.WriteSourceFile("book-two.m4b");
+
+        var loadedCsv = WriteCsv(workspace, "Book One,Author,book-one");
+        var requestedCsv = WriteCsv(workspace, "Book Two,Author,book-two");
+
+        var service = new SortService();
+        await service.ParseBooks(loadedCsv);
+
+        Assert.True(service.TryStartSort(requestedCsv, workspace.Source, workspace.Destination, out var sortTask));
+        await sortTask;
+
+        Assert.Equal(["Author/Book Two.m4b"], workspace.DestinationFiles());
+    }
+
+    private static string WriteCsv(TempWorkspace workspace, params string[] rows)
+    {
+        var path = Path.Combine(workspace.Root, $"{Guid.NewGuid():N}.csv");
+        File.WriteAllText(path, "Title,Author,File name\n" + string.Join("\n", rows) + "\n");
+        return path;
+    }
+}

--- a/AudioFileSorter.Tests/SortServiceTests.cs
+++ b/AudioFileSorter.Tests/SortServiceTests.cs
@@ -1,3 +1,4 @@
+using AudioFileSorter.Model;
 using ManagerApi.Services;
 
 namespace AudioFileSorter.Tests;
@@ -22,6 +23,46 @@ public class SortServiceTests
         Assert.Equal(1, progress.CopiedBooks);
         Assert.False(service.IsSorting);
         Assert.Equal(["Tolkien/The Hobbit.m4b"], workspace.DestinationFiles());
+    }
+
+    [Fact]
+    public async Task A_late_progress_report_cannot_un_finish_a_completed_sort()
+    {
+        // A per-book report delivered after the run ended used to overwrite the completed state.
+        // The UI stops polling on that flag, so losing it left it spinning on a finished run.
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("the-hobbit.m4b");
+        var csvPath = WriteCsv(workspace, "The Hobbit,Tolkien,the-hobbit");
+
+        var service = new SortService();
+        Assert.True(service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out var sortTask));
+        await sortTask;
+        Assert.True(service.GetProgress().IsComplete);
+
+        service.SetProgress(new SortProgressInfo { CurrentBook = 1, TotalBooks = 25, Percentage = 4 });
+
+        var progress = service.GetProgress();
+        Assert.True(progress.IsComplete);
+        Assert.Equal(100, progress.Percentage);
+    }
+
+    [Fact]
+    public async Task A_new_run_clears_the_completed_state_of_the_previous_one()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("the-hobbit.m4b");
+        var csvPath = WriteCsv(workspace, "The Hobbit,Tolkien,the-hobbit");
+
+        var service = new SortService();
+        Assert.True(service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out var first));
+        await first;
+
+        Assert.True(service.TryStartSort(csvPath, workspace.Source, workspace.Destination, out var second));
+        await second;
+
+        var progress = service.GetProgress();
+        Assert.True(progress.IsComplete);
+        Assert.Equal(1, progress.TotalBooks);
     }
 
     [Fact]

--- a/AudioFileSorter.Tests/SortServiceTests.cs
+++ b/AudioFileSorter.Tests/SortServiceTests.cs
@@ -26,6 +26,38 @@ public class SortServiceTests
     }
 
     [Fact]
+    public async Task TryStartSort_passes_the_requested_update_check_through_to_the_sorter()
+    {
+        using var workspace = new TempWorkspace();
+
+        // Same length, differing only outside the chunks the quick check samples, so the mode the
+        // service hands down is the only thing that decides whether this book is replaced.
+        var (original, edited) = TempWorkspace.SameSizeEditedPair();
+
+        workspace.WriteSourceFile("the-hobbit.m4b", edited);
+        var destination = workspace.WriteDestinationFile(Path.Combine("Tolkien", "The Hobbit.m4b"), original);
+        var csvPath = WriteCsv(workspace, "The Hobbit,Tolkien,the-hobbit");
+
+        var quickService = new SortService();
+        Assert.True(quickService.TryStartSort(
+            csvPath, workspace.Source, workspace.Destination,
+            new SortOptions { ComparisonMode = FileComparisonMode.Quick }, out var quickTask));
+        await quickTask;
+
+        Assert.Equal(0, quickService.GetProgress().UpdatedBooks);
+        Assert.Equal(original, File.ReadAllText(destination));
+
+        var fullService = new SortService();
+        Assert.True(fullService.TryStartSort(
+            csvPath, workspace.Source, workspace.Destination,
+            new SortOptions { ComparisonMode = FileComparisonMode.Full }, out var fullTask));
+        await fullTask;
+
+        Assert.Equal(1, fullService.GetProgress().UpdatedBooks);
+        Assert.Equal(edited, File.ReadAllText(destination));
+    }
+
+    [Fact]
     public async Task A_late_progress_report_cannot_un_finish_a_completed_sort()
     {
         // A per-book report delivered after the run ended used to overwrite the completed state.

--- a/AudioFileSorter.Tests/TempWorkspace.cs
+++ b/AudioFileSorter.Tests/TempWorkspace.cs
@@ -62,6 +62,24 @@ public sealed class TempWorkspace : IDisposable
             .ToArray();
     }
 
+    /// <summary>
+    /// Two equal-length contents that are identical in the first, middle and last 4 KB — the three
+    /// windows the quick update check samples — and differ only in between. Stands in for an author
+    /// re-issuing a book without changing its size.
+    /// </summary>
+    public static (string Original, string Edited) SameSizeEditedPair()
+    {
+        const int chunk = 4096;
+        var head = new string('h', chunk);
+        var middle = new string('m', chunk);
+        var tail = new string('t', chunk);
+
+        var original = head + new string('a', chunk * 4) + middle + new string('a', chunk * 4) + tail;
+        var edited = head + new string('a', chunk * 2) + new string('b', chunk * 2) + middle + new string('a', chunk * 4) + tail;
+
+        return (original, edited);
+    }
+
     public static OpenAudible Book(
         string? title = "A Book",
         string? author = "An Author",

--- a/AudioFileSorter.Tests/TempWorkspace.cs
+++ b/AudioFileSorter.Tests/TempWorkspace.cs
@@ -1,0 +1,106 @@
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter.Tests;
+
+/// <summary>A throwaway source/destination pair on disk for the copy tests.</summary>
+public sealed class TempWorkspace : IDisposable
+{
+    public TempWorkspace()
+    {
+        Root = Path.Combine(Path.GetTempPath(), "oabo-tests", Guid.NewGuid().ToString("N"));
+        Source = Path.Combine(Root, "source");
+        Destination = Path.Combine(Root, "destination");
+        Directory.CreateDirectory(Source);
+        Directory.CreateDirectory(Destination);
+    }
+
+    public string Root { get; }
+    public string Source { get; }
+    public string Destination { get; }
+
+    /// <summary>Writes a file into the source folder and returns its full path.</summary>
+    public string WriteSourceFile(string relativeName, string content = "audio")
+    {
+        var path = Path.Combine(Source, relativeName);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    public string WriteDestinationFile(string relativePath, string content)
+    {
+        var path = Path.Combine(Destination, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    /// <summary>All files under the destination, as paths relative to it, using '/' separators.</summary>
+    public string[] DestinationFiles()
+    {
+        if (!Directory.Exists(Destination))
+        {
+            return [];
+        }
+
+        return Directory.GetFiles(Destination, "*", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(Destination, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public string[] DestinationDirectories()
+    {
+        if (!Directory.Exists(Destination))
+        {
+            return [];
+        }
+
+        return Directory.GetDirectories(Destination, "*", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(Destination, path).Replace(Path.DirectorySeparatorChar, '/'))
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    public static OpenAudible Book(
+        string? title = "A Book",
+        string? author = "An Author",
+        string? filename = "a-book",
+        string? shortTitle = null,
+        string? seriesName = null,
+        string? seriesSequence = null,
+        string? m4b = "Yes",
+        string? mp3 = null,
+        string? pdf = null,
+        string? filePaths = null)
+    {
+        return new OpenAudible
+        {
+            Title = title,
+            Author = author,
+            Filename = filename,
+            ShortTitle = shortTitle,
+            SeriesName = seriesName,
+            SeriesSequence = seriesSequence,
+            M4B = m4b,
+            MP3 = mp3,
+            PDF = pdf,
+            FilePaths = filePaths
+        };
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp folder is not worth failing a test run over.
+        }
+    }
+}

--- a/AudioFileSorter.Tests/TempWorkspace.cs
+++ b/AudioFileSorter.Tests/TempWorkspace.cs
@@ -63,21 +63,81 @@ public sealed class TempWorkspace : IDisposable
     }
 
     /// <summary>
+    /// Layout of <see cref="SameSizeEditedPair"/>, in 4 KB blocks. The quick update check samples
+    /// the first block, the block straddling the midpoint, and the last block:
+    ///
+    ///   block:   0      1  2  3  4      5       6  7  8  9     10
+    ///   content: head   a  a  a  a      middle  a  a  a  a     tail
+    ///   sampled: yes                    yes                    yes
+    ///
+    /// Total length is 11 * 4096 = 45056, so the middle sample covers bytes 20480..24575 — exactly
+    /// block 5. Blocks 1..4 and 6..9 are never read by the quick check.
+    /// </summary>
+    public enum SampleWindow
+    {
+        /// <summary>Block 0, bytes 0..4095.</summary>
+        Head,
+
+        /// <summary>Block 5, bytes 20480..24575.</summary>
+        Middle,
+
+        /// <summary>Block 10, bytes 40960..45055.</summary>
+        Tail
+    }
+
+    private const int SampleChunk = 4096;
+
+    /// <summary>
     /// Two equal-length contents that are identical in the first, middle and last 4 KB — the three
     /// windows the quick update check samples — and differ only in between. Stands in for an author
     /// re-issuing a book without changing its size.
     /// </summary>
     public static (string Original, string Edited) SameSizeEditedPair()
     {
-        const int chunk = 4096;
-        var head = new string('h', chunk);
-        var middle = new string('m', chunk);
-        var tail = new string('t', chunk);
+        var blocks = OriginalBlocks();
 
-        var original = head + new string('a', chunk * 4) + middle + new string('a', chunk * 4) + tail;
-        var edited = head + new string('a', chunk * 2) + new string('b', chunk * 2) + middle + new string('a', chunk * 4) + tail;
+        // Edit blocks 3 and 4: inside the untouched span, and two whole blocks clear of both the
+        // head sample (block 0) and the middle sample (block 5).
+        var edited = (string[])blocks.Clone();
+        edited[3] = new string('b', SampleChunk);
+        edited[4] = new string('b', SampleChunk);
 
-        return (original, edited);
+        return (string.Concat(blocks), string.Concat(edited));
+    }
+
+    /// <summary>
+    /// The same pair, but with the edit placed inside one of the windows the quick check samples,
+    /// so quick mode is expected to notice it.
+    /// </summary>
+    public static (string Original, string Edited) SameSizeEditInWindow(SampleWindow window)
+    {
+        var blocks = OriginalBlocks();
+        var edited = (string[])blocks.Clone();
+
+        var index = window switch
+        {
+            SampleWindow.Head => 0,
+            SampleWindow.Middle => 5,
+            SampleWindow.Tail => 10,
+            _ => throw new ArgumentOutOfRangeException(nameof(window))
+        };
+
+        edited[index] = new string('b', SampleChunk);
+        return (string.Concat(blocks), string.Concat(edited));
+    }
+
+    private static string[] OriginalBlocks()
+    {
+        return
+        [
+            new string('h', SampleChunk),
+            new string('a', SampleChunk), new string('a', SampleChunk),
+            new string('a', SampleChunk), new string('a', SampleChunk),
+            new string('m', SampleChunk),
+            new string('a', SampleChunk), new string('a', SampleChunk),
+            new string('a', SampleChunk), new string('a', SampleChunk),
+            new string('t', SampleChunk)
+        ];
     }
 
     public static OpenAudible Book(

--- a/AudioFileSorter.Tests/UpdateCheckTests.cs
+++ b/AudioFileSorter.Tests/UpdateCheckTests.cs
@@ -65,6 +65,29 @@ public class UpdateCheckTests
         Assert.Equal(original, File.ReadAllText(destination));
     }
 
+    /// <summary>
+    /// The other half of the quick check's contract: what it samples, it must actually compare.
+    /// Without this, the sampling loop could be deleted entirely and every other test would still
+    /// pass, because they only ever assert that quick mode does *not* notice a difference.
+    /// </summary>
+    [Theory]
+    [InlineData(TempWorkspace.SampleWindow.Head)]
+    [InlineData(TempWorkspace.SampleWindow.Middle)]
+    [InlineData(TempWorkspace.SampleWindow.Tail)]
+    public async Task Quick_mode_replaces_a_same_size_edit_inside_a_sampled_chunk(TempWorkspace.SampleWindow window)
+    {
+        using var workspace = new TempWorkspace();
+        var (original, edited) = TempWorkspace.SameSizeEditInWindow(window);
+        workspace.WriteSourceFile("a-book.m4b", edited);
+        var destination = workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), original);
+
+        var summary = await Sort(workspace, FileComparisonMode.Quick, TempWorkspace.Book());
+
+        Assert.Equal(1, summary.CopiedBooks);
+        Assert.Equal(1, summary.UpdatedBooks);
+        Assert.Equal(edited, File.ReadAllText(destination));
+    }
+
     [Fact]
     public async Task Full_mode_replaces_a_same_size_edit_between_the_sampled_chunks()
     {
@@ -144,16 +167,110 @@ public class UpdateCheckTests
         Assert.Equal(1, reports[^1].UpdatedBooks);
     }
 
+    /// <summary>
+    /// Cancels mid-run, once books are actually being compared and copied, rather than before the
+    /// first one — a run that aborts at the starting gate never enters the byte-for-byte loop and
+    /// proves nothing about it.
+    /// </summary>
     [Fact]
-    public async Task Full_mode_honours_cancellation()
+    public async Task Full_mode_honours_cancellation_once_it_is_already_comparing()
     {
         using var workspace = new TempWorkspace();
         var books = new List<OpenAudible>();
-        for (var i = 0; i < 200; i++)
+        for (var i = 0; i < 300; i++)
         {
-            workspace.WriteSourceFile($"book-{i}.m4b", new string((char)('a' + (i % 26)), 40_000));
+            var content = new string((char)('a' + (i % 26)), 200_000);
+            workspace.WriteSourceFile($"book-{i}.m4b", content);
+
+            // Half the books already exist at the destination with identical contents, so the run
+            // has to read both files in full before deciding to skip them.
+            if (i % 2 == 0)
+            {
+                workspace.WriteDestinationFile(Path.Combine("An Author", $"Book {i}.m4b"), content);
+            }
+
             books.Add(TempWorkspace.Book(title: $"Book {i}", filename: $"book-{i}"));
         }
+
+        using var cancellation = new CancellationTokenSource();
+        var comparedBeforeCancel = 0;
+
+        var progress = new InlineTestProgress(report =>
+        {
+            comparedBeforeCancel = report.CurrentBook;
+            if (report.CurrentBook >= 5)
+            {
+                cancellation.Cancel();
+            }
+        });
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new FileSorter().SortAudioFiles(
+                workspace.Source,
+                workspace.Destination,
+                books,
+                new SortOptions { ComparisonMode = FileComparisonMode.Full },
+                progress,
+                cancellation.Token));
+
+        Assert.True(comparedBeforeCancel >= 5, $"expected the run to get going before cancelling, got {comparedBeforeCancel}");
+        Assert.True(comparedBeforeCancel < books.Count, "the run finished instead of being cancelled");
+
+        Assert.Empty(Directory.GetFiles(workspace.Destination, "*.oabo-partial", SearchOption.AllDirectories));
+
+        // Whatever was written before the cancel must be complete, not truncated.
+        foreach (var file in Directory.GetFiles(workspace.Destination, "*.m4b", SearchOption.AllDirectories))
+        {
+            Assert.Equal(200_000, new FileInfo(file).Length);
+        }
+    }
+
+    /// <summary>
+    /// The byte-for-byte comparison is the only unbounded loop in a sort. On a large library a
+    /// cancelled run must stop inside it, not after it — otherwise Cancel reports success while
+    /// the backend keeps reading whole files.
+    /// </summary>
+    [Fact]
+    public async Task The_byte_for_byte_comparison_stops_when_cancelled()
+    {
+        using var workspace = new TempWorkspace();
+        var content = new string('z', 2_000_000);
+        var first = workspace.WriteSourceFile("a-book.m4b", content);
+        var second = workspace.WriteDestinationFile("copy.m4b", content);
+
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            FileSorter.AreFilesIdenticalAsync(first, second, cancellation.Token));
+    }
+
+    [Fact]
+    public async Task The_byte_for_byte_comparison_still_reports_identical_files_as_identical()
+    {
+        using var workspace = new TempWorkspace();
+        var content = new string('z', 2_000_000);
+        var first = workspace.WriteSourceFile("a-book.m4b", content);
+        var second = workspace.WriteDestinationFile("copy.m4b", content);
+
+        Assert.True(await FileSorter.AreFilesIdenticalAsync(first, second, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task The_byte_for_byte_comparison_spots_a_difference_in_the_final_block()
+    {
+        using var workspace = new TempWorkspace();
+        var first = workspace.WriteSourceFile("a-book.m4b", new string('z', 2_000_000) + "end-a");
+        var second = workspace.WriteDestinationFile("copy.m4b", new string('z', 2_000_000) + "end-b");
+
+        Assert.False(await FileSorter.AreFilesIdenticalAsync(first, second, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Full_mode_aborts_before_touching_anything_when_the_token_is_already_cancelled()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b", "audio");
 
         using var cancellation = new CancellationTokenSource();
         await cancellation.CancelAsync();
@@ -162,11 +279,11 @@ public class UpdateCheckTests
             new FileSorter().SortAudioFiles(
                 workspace.Source,
                 workspace.Destination,
-                books,
+                [TempWorkspace.Book()],
                 new SortOptions { ComparisonMode = FileComparisonMode.Full },
                 cancellationToken: cancellation.Token));
 
-        Assert.Empty(Directory.GetFiles(workspace.Destination, "*.oabo-partial", SearchOption.AllDirectories));
+        Assert.Empty(workspace.DestinationFiles());
     }
 
     [Fact]

--- a/AudioFileSorter.Tests/UpdateCheckTests.cs
+++ b/AudioFileSorter.Tests/UpdateCheckTests.cs
@@ -1,0 +1,238 @@
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter.Tests;
+
+/// <summary>
+/// The two update checks. Authors re-issue audiobooks, so a book already at the destination has to
+/// be replaced when its source changes — the two modes differ only in how hard they look.
+/// </summary>
+public class UpdateCheckTests
+{
+    [Theory]
+    [InlineData(FileComparisonMode.Quick)]
+    [InlineData(FileComparisonMode.Full)]
+    public async Task Either_mode_replaces_a_book_whose_size_changed(FileComparisonMode mode)
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b", "the-re-recorded-and-longer-edition");
+        workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), "old");
+
+        var summary = await Sort(workspace, mode, TempWorkspace.Book());
+
+        Assert.Equal(1, summary.CopiedBooks);
+        Assert.Equal(1, summary.UpdatedBooks);
+        Assert.Equal(
+            "the-re-recorded-and-longer-edition",
+            File.ReadAllText(Path.Combine(workspace.Destination, "An Author", "A Book.m4b")));
+    }
+
+    [Theory]
+    [InlineData(FileComparisonMode.Quick)]
+    [InlineData(FileComparisonMode.Full)]
+    public async Task Either_mode_leaves_an_identical_book_alone(FileComparisonMode mode)
+    {
+        using var workspace = new TempWorkspace();
+        var content = new string('x', 300_000);
+        workspace.WriteSourceFile("a-book.m4b", content);
+        var destination = workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), content);
+        var writtenAt = File.GetLastWriteTimeUtc(destination);
+
+        var summary = await Sort(workspace, mode, TempWorkspace.Book());
+
+        Assert.Equal(0, summary.CopiedBooks);
+        Assert.Equal(0, summary.UpdatedBooks);
+        Assert.Equal(1, summary.SkippedBooks);
+        Assert.Equal(writtenAt, File.GetLastWriteTimeUtc(destination));
+    }
+
+    /// <summary>
+    /// The sampled check reads the first, middle and last 4 KB. A re-release that kept the exact
+    /// same length and changed only the space between those windows is invisible to it — which is
+    /// the whole reason the full check exists.
+    /// </summary>
+    [Fact]
+    public async Task Quick_mode_misses_a_same_size_edit_between_the_sampled_chunks()
+    {
+        using var workspace = new TempWorkspace();
+        var (original, edited) = TempWorkspace.SameSizeEditedPair();
+        workspace.WriteSourceFile("a-book.m4b", edited);
+        var destination = workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), original);
+
+        var summary = await Sort(workspace, FileComparisonMode.Quick, TempWorkspace.Book());
+
+        Assert.Equal(0, summary.CopiedBooks);
+        Assert.Equal(1, summary.SkippedBooks);
+        Assert.Equal(original, File.ReadAllText(destination));
+    }
+
+    [Fact]
+    public async Task Full_mode_replaces_a_same_size_edit_between_the_sampled_chunks()
+    {
+        using var workspace = new TempWorkspace();
+        var (original, edited) = TempWorkspace.SameSizeEditedPair();
+        workspace.WriteSourceFile("a-book.m4b", edited);
+        var destination = workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), original);
+
+        var summary = await Sort(workspace, FileComparisonMode.Full, TempWorkspace.Book());
+
+        Assert.Equal(1, summary.CopiedBooks);
+        Assert.Equal(1, summary.UpdatedBooks);
+        Assert.Equal(0, summary.FailedBooks);
+        Assert.Equal(edited, File.ReadAllText(destination));
+    }
+
+    [Fact]
+    public async Task Full_mode_replaces_a_changed_companion_pdf()
+    {
+        using var workspace = new TempWorkspace();
+        var (original, edited) = TempWorkspace.SameSizeEditedPair();
+        workspace.WriteSourceFile("a-book.m4b", "audio");
+        workspace.WriteSourceFile("a-book.pdf", edited);
+        workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), "audio");
+        var destinationPdf = workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.pdf"), original);
+
+        var summary = await Sort(workspace, FileComparisonMode.Full, TempWorkspace.Book());
+
+        Assert.Equal(1, summary.UpdatedBooks);
+        Assert.Equal(edited, File.ReadAllText(destinationPdf));
+    }
+
+    [Fact]
+    public async Task A_brand_new_book_counts_as_copied_but_not_as_updated()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b", "audio");
+
+        var summary = await Sort(workspace, FileComparisonMode.Full, TempWorkspace.Book());
+
+        Assert.Equal(1, summary.CopiedBooks);
+        Assert.Equal(0, summary.UpdatedBooks);
+    }
+
+    [Fact]
+    public async Task Quick_is_the_default_when_no_options_are_supplied()
+    {
+        using var workspace = new TempWorkspace();
+        var (original, edited) = TempWorkspace.SameSizeEditedPair();
+        workspace.WriteSourceFile("a-book.m4b", edited);
+        var destination = workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), original);
+
+        var summary = await new FileSorter().SortAudioFiles(
+            workspace.Source, workspace.Destination, [TempWorkspace.Book()]);
+
+        Assert.Equal(0, summary.CopiedBooks);
+        Assert.Equal(original, File.ReadAllText(destination));
+    }
+
+    [Fact]
+    public async Task Full_mode_reports_updates_through_progress()
+    {
+        using var workspace = new TempWorkspace();
+        var (original, edited) = TempWorkspace.SameSizeEditedPair();
+        workspace.WriteSourceFile("a-book.m4b", edited);
+        workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), original);
+
+        var reports = new List<SortProgressInfo>();
+        await new FileSorter().SortAudioFiles(
+            workspace.Source,
+            workspace.Destination,
+            [TempWorkspace.Book()],
+            new SortOptions { ComparisonMode = FileComparisonMode.Full },
+            new InlineTestProgress(reports.Add));
+
+        Assert.Contains(reports, report => report.UpdatedBooks == 1);
+        Assert.Equal(1, reports[^1].UpdatedBooks);
+    }
+
+    [Fact]
+    public async Task Full_mode_honours_cancellation()
+    {
+        using var workspace = new TempWorkspace();
+        var books = new List<OpenAudible>();
+        for (var i = 0; i < 200; i++)
+        {
+            workspace.WriteSourceFile($"book-{i}.m4b", new string((char)('a' + (i % 26)), 40_000));
+            books.Add(TempWorkspace.Book(title: $"Book {i}", filename: $"book-{i}"));
+        }
+
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            new FileSorter().SortAudioFiles(
+                workspace.Source,
+                workspace.Destination,
+                books,
+                new SortOptions { ComparisonMode = FileComparisonMode.Full },
+                cancellationToken: cancellation.Token));
+
+        Assert.Empty(Directory.GetFiles(workspace.Destination, "*.oabo-partial", SearchOption.AllDirectories));
+    }
+
+    [Fact]
+    public async Task Full_mode_still_replaces_a_truncated_destination()
+    {
+        using var workspace = new TempWorkspace();
+        workspace.WriteSourceFile("a-book.m4b", new string('y', 100_000));
+        var destination = workspace.WriteDestinationFile(Path.Combine("An Author", "A Book.m4b"), new string('y', 40_000));
+
+        var summary = await Sort(workspace, FileComparisonMode.Full, TempWorkspace.Book());
+
+        Assert.Equal(1, summary.UpdatedBooks);
+        Assert.Equal(100_000, new FileInfo(destination).Length);
+    }
+
+    [Theory]
+    [InlineData(null, FileComparisonMode.Quick)]
+    [InlineData("", FileComparisonMode.Quick)]
+    [InlineData("   ", FileComparisonMode.Quick)]
+    [InlineData("quick", FileComparisonMode.Quick)]
+    [InlineData("QUICK", FileComparisonMode.Quick)]
+    [InlineData(" Fast ", FileComparisonMode.Quick)]
+    [InlineData("sampled", FileComparisonMode.Quick)]
+    [InlineData("full", FileComparisonMode.Full)]
+    [InlineData("Full", FileComparisonMode.Full)]
+    [InlineData("verify", FileComparisonMode.Full)]
+    [InlineData("exact", FileComparisonMode.Full)]
+    [InlineData("content", FileComparisonMode.Full)]
+    public void Comparison_mode_parses_the_spellings_the_api_accepts(string? value, FileComparisonMode expected)
+    {
+        Assert.True(SortOptions.TryParseComparisonMode(value, out var mode));
+        Assert.Equal(expected, mode);
+    }
+
+    [Theory]
+    [InlineData("thorough")]
+    [InlineData("yes")]
+    [InlineData("1")]
+    [InlineData("quick-ish")]
+    public void An_unrecognised_comparison_mode_is_rejected_rather_than_downgraded(string value)
+    {
+        Assert.False(SortOptions.TryParseComparisonMode(value, out _));
+    }
+
+    [Theory]
+    [InlineData(FileComparisonMode.Quick, "quick")]
+    [InlineData(FileComparisonMode.Full, "full")]
+    public void Comparison_mode_round_trips_through_its_wire_value(FileComparisonMode mode, string expected)
+    {
+        Assert.Equal(expected, SortOptions.ToWireValue(mode));
+        Assert.True(SortOptions.TryParseComparisonMode(SortOptions.ToWireValue(mode), out var parsed));
+        Assert.Equal(mode, parsed);
+    }
+
+    private static Task<SortSummary> Sort(TempWorkspace workspace, FileComparisonMode mode, params OpenAudible[] books)
+    {
+        return new FileSorter().SortAudioFiles(
+            workspace.Source,
+            workspace.Destination,
+            [.. books],
+            new SortOptions { ComparisonMode = mode });
+    }
+
+    /// <summary>Reports on the calling thread so the assertions do not race the thread pool.</summary>
+    private sealed class InlineTestProgress(Action<SortProgressInfo> handler) : IProgress<SortProgressInfo>
+    {
+        public void Report(SortProgressInfo value) => handler(value);
+    }
+}

--- a/AudioFileSorter/AudioFileSorter.csproj
+++ b/AudioFileSorter/AudioFileSorter.csproj
@@ -12,4 +12,8 @@
       <PackageReference Include="CsvHelper" Version="33.0.1" />
     </ItemGroup>
 
+    <ItemGroup>
+      <InternalsVisibleTo Include="AudioFileSorter.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/AudioFileSorter/BookNaming.cs
+++ b/AudioFileSorter/BookNaming.cs
@@ -1,0 +1,155 @@
+using System.Text.RegularExpressions;
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter;
+
+/// <summary>
+/// Derives the folder and file names for a book from its OpenAudible metadata.
+/// Pure functions only: nothing here touches the filesystem and nothing mutates the
+/// <see cref="OpenAudible"/> instance it is given, so the parsed library stays exactly as it was
+/// read from the CSV even after a sort has run.
+/// </summary>
+public static class BookNaming
+{
+    private static readonly string[] ContributorDescriptors =
+    [
+        "foreword", "afterword", "editor", "contributor", "adaptation", "music",
+        "translator", "translatoreditor", "introduction", "preface", "illustrator"
+    ];
+
+    private static readonly string[] KnownNonAuthorSegments =
+        ["the great courses", "crystal lake publishing", "crystal lake audio"];
+
+    private static readonly Regex SequenceValueRegex =
+        new(@"(?<value>\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?)", RegexOptions.Compiled);
+
+    public const string UnknownAuthor = "Unknown";
+    public const string UnknownTitle = "Unknown";
+
+    /// <summary>Builds the naming plan for a book without modifying the book itself.</summary>
+    public static BookSortPlan BuildPlan(OpenAudible book)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        var seriesName = PathSanitizer.SanitizeSegment(book.SeriesName);
+
+        return new BookSortPlan
+        {
+            Author = ResolveAuthor(book.Author),
+            SeriesName = seriesName,
+            // A sequence without a series has nowhere to live, so drop it rather than creating
+            // a stray "Book 3" folder directly under the author.
+            SeriesSequence = seriesName is null ? null : ResolveSeriesSequence(book.SeriesSequence),
+            FileStem = ResolveFileStem(book)
+        };
+    }
+
+    /// <summary>
+    /// Cleans an author cell, which in OpenAudible exports frequently carries contributors
+    /// ("Jane Doe, John Roe - translator") and publisher noise alongside the real author.
+    /// </summary>
+    public static string ResolveAuthor(string? rawAuthor)
+    {
+        var sanitized = PathSanitizer.SanitizeSegment(rawAuthor);
+        if (sanitized is null)
+        {
+            return UnknownAuthor;
+        }
+
+        var authorSegments = new List<string>();
+        foreach (var rawSegment in sanitized.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var segment = rawSegment.Trim();
+            var namePart = segment;
+            string? descriptorPart = null;
+
+            var separatorIndex = segment.IndexOf(" - ", StringComparison.Ordinal);
+            if (separatorIndex >= 0)
+            {
+                namePart = segment[..separatorIndex].Trim();
+                descriptorPart = segment[(separatorIndex + 3)..].Trim();
+            }
+
+            if (!string.IsNullOrWhiteSpace(descriptorPart) && IsContributorDescriptor(descriptorPart))
+            {
+                if (authorSegments.Count > 0)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (authorSegments.Count > 0 && IsKnownNonAuthorSegment(namePart))
+            {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(namePart))
+            {
+                authorSegments.Add(namePart);
+            }
+        }
+
+        if (authorSegments.Count == 0)
+        {
+            return UnknownAuthor;
+        }
+
+        var joined = string.Join(", ", authorSegments.Distinct(StringComparer.OrdinalIgnoreCase));
+
+        // Joining segments can push the value back over the segment budget.
+        return PathSanitizer.SanitizeSegment(joined) ?? UnknownAuthor;
+    }
+
+    /// <summary>Extracts the numeric part of a series sequence ("Book 3", "3.5", "2-3").</summary>
+    public static string? ResolveSeriesSequence(string? rawSequence)
+    {
+        var sanitized = PathSanitizer.SanitizeSegment(rawSequence);
+        if (sanitized is null)
+        {
+            return null;
+        }
+
+        if (sanitized.StartsWith("Book ", StringComparison.OrdinalIgnoreCase))
+        {
+            sanitized = sanitized[5..].Trim();
+        }
+
+        var match = SequenceValueRegex.Match(sanitized);
+        return match.Success ? match.Groups["value"].Value : null;
+    }
+
+    /// <summary>
+    /// Picks the base name for the copied file. Falling through Short Title, Title and the
+    /// source file name matters: when an export has no "Short Title" column every book would
+    /// otherwise be written as "Unknown", and each one would overwrite the last.
+    /// </summary>
+    public static string ResolveFileStem(OpenAudible book)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        var fileNameStem = string.IsNullOrWhiteSpace(book.Filename)
+            ? null
+            : Path.GetFileNameWithoutExtension(book.Filename.Trim());
+
+        return PathSanitizer.SanitizeSegmentOrFallback(
+            UnknownTitle,
+            book.ShortTitle,
+            book.Title,
+            fileNameStem,
+            book.ASIN);
+    }
+
+    private static bool IsContributorDescriptor(string value)
+    {
+        var normalized = value.Trim().ToLowerInvariant();
+        return ContributorDescriptors.Any(normalized.Contains);
+    }
+
+    private static bool IsKnownNonAuthorSegment(string value)
+    {
+        var normalized = value.Trim().ToLowerInvariant();
+        return Array.IndexOf(KnownNonAuthorSegments, normalized) >= 0;
+    }
+}

--- a/AudioFileSorter/CsvParser.cs
+++ b/AudioFileSorter/CsvParser.cs
@@ -1,37 +1,141 @@
-﻿using System.Collections;
 using System.Globalization;
+using System.Text;
 using AudioFileSorter.Model;
 using CsvHelper;
 using CsvHelper.Configuration;
-using System.Linq;
-
 
 namespace AudioFileSorter;
 
+/// <summary>Reads an OpenAudible book list export.</summary>
 public class CsvParser
 {
+    private const int MaxReportedWarnings = 50;
+
+    /// <summary>Columns that identify a file as an OpenAudible export.</summary>
+    private static readonly string[] RecognisedHeaders =
+        ["title", "author", "file name", "filename", "file paths", "asin", "short title"];
+
+    /// <summary>Parses a CSV export, skipping rows that cannot be read.</summary>
+    /// <exception cref="ArgumentException">No path was supplied.</exception>
+    /// <exception cref="FileNotFoundException">The file does not exist.</exception>
+    /// <exception cref="InvalidDataException">The file is not an OpenAudible export.</exception>
     public async Task<List<OpenAudible>> ParseDataCsv(string? fullPath, CancellationToken token)
     {
-        using var reader = new StreamReader(fullPath ?? throw new ArgumentNullException(nameof(fullPath)));
-        using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
+        var result = await ParseAsync(fullPath, token);
+        return result.Books;
+    }
+
+    /// <summary>
+    /// Parses a CSV export and reports what had to be skipped, so the caller can tell the
+    /// difference between "empty library" and "nothing in this file could be read".
+    /// </summary>
+    public async Task<CsvParseResult> ParseAsync(string? fullPath, CancellationToken token)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullPath);
+
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"CSV file not found: {fullPath}", fullPath);
+        }
+
+        var warnings = new List<string>();
+        var skippedRows = 0;
+
+        var configuration = new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            // OpenAudible has shipped comma and tab separated exports over the years.
+            DetectDelimiter = true,
+            DetectDelimiterValues = [",", "\t", ";", "|"],
+            TrimOptions = TrimOptions.Trim,
+            IgnoreBlankLines = true,
+            MissingFieldFound = null,
+            HeaderValidated = null,
+            BadDataFound = args =>
+                AddWarning(warnings, $"Malformed data on row {args.Context.Parser?.Row ?? 0} was read as-is.")
+        };
+
+        // A UTF-8 BOM in front of the first header would otherwise turn "Title" into "﻿Title"
+        // and silently drop the column.
+        using var reader = new StreamReader(fullPath, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), detectEncodingFromByteOrderMarks: true);
+        using var csv = new CsvReader(reader, configuration);
+        csv.Context.RegisterClassMap<AudiobookMap>();
+
+        var books = new List<OpenAudible>();
+
         try
         {
-            var result = new List<OpenAudible>();
-            csv.Context.RegisterClassMap<AudiobookMap>();
-            await foreach (var openAudible in csv.GetRecordsAsync<OpenAudible>(token))
+            if (!await csv.ReadAsync() || !csv.ReadHeader())
             {
-                result.Add(openAudible);
+                throw new InvalidDataException("The CSV file is empty or has no header row.");
             }
-            return result;
+
+            EnsureLooksLikeOpenAudibleExport(csv.HeaderRecord);
+
+            while (await csv.ReadAsync())
+            {
+                token.ThrowIfCancellationRequested();
+
+                try
+                {
+                    books.Add(csv.GetRecord<OpenAudible>());
+                }
+                catch (Exception ex) when (ex is CsvHelperException or FormatException)
+                {
+                    // One unreadable row must not cost the user the other several hundred.
+                    skippedRows++;
+                    AddWarning(warnings, $"Row {csv.Context.Parser?.Row ?? 0} could not be read and was skipped: {ex.Message}");
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (CsvHelperException ex)
         {
-            Console.WriteLine($"CSV Parsing Error: {ex.Message}");
-            throw;
+            throw new InvalidDataException($"The CSV file could not be read: {ex.Message}", ex);
         }
-        finally
+
+        return new CsvParseResult
         {
-            reader.Close();
+            Books = books,
+            SkippedRows = skippedRows,
+            Warnings = warnings
+        };
+    }
+
+    private static void EnsureLooksLikeOpenAudibleExport(string[]? headerRecord)
+    {
+        var headers = headerRecord ?? [];
+        var recognised = headers.Any(header =>
+            !string.IsNullOrWhiteSpace(header) &&
+            RecognisedHeaders.Contains(header.Trim().ToLowerInvariant()));
+
+        if (!recognised)
+        {
+            throw new InvalidDataException(
+                "This file does not look like an OpenAudible export: none of the expected columns " +
+                "(Title, Author, File name, File Paths) were found. Export your library from " +
+                "OpenAudible with File > Export and try again.");
         }
     }
+
+    private static void AddWarning(List<string> warnings, string message)
+    {
+        if (warnings.Count < MaxReportedWarnings)
+        {
+            warnings.Add(message);
+        }
+    }
+}
+
+/// <summary>Outcome of reading a book list export.</summary>
+public sealed class CsvParseResult
+{
+    public List<OpenAudible> Books { get; init; } = [];
+
+    /// <summary>Rows that could not be read and were skipped.</summary>
+    public int SkippedRows { get; init; }
+
+    public IReadOnlyList<string> Warnings { get; init; } = [];
 }

--- a/AudioFileSorter/Model/AudiobookMap.cs
+++ b/AudioFileSorter/Model/AudiobookMap.cs
@@ -1,26 +1,27 @@
-﻿using CsvHelper.Configuration;
-using CsvHelper.TypeConversion;
+using CsvHelper.Configuration;
 
 namespace AudioFileSorter.Model;
 
+/// <summary>
+/// Maps OpenAudible export columns onto <see cref="OpenAudible"/>.
+///
+/// Every column is optional. Exports vary between OpenAudible versions and platforms, and a
+/// missing column should degrade the result for that one field rather than fail the import; the
+/// parser checks separately that the file looks like a book list at all.
+/// </summary>
 public sealed class AudiobookMap : ClassMap<OpenAudible>
 {
     public AudiobookMap()
     {
-        // Mandatory Fields
         Map(m => m.Key).Name("Key").Optional();
-        Map(m => m.Title).Name("Title");
-        Map(m => m.Author).Name("Author");
-        Map(m => m.Filename).Name("File name");
-        Map(m => m.FilePaths).Name("File Paths");
+        Map(m => m.Title).Name("Title").Optional();
+        Map(m => m.Author).Name("Author").Optional();
+        Map(m => m.Filename).Name("File name", "Filename", "File Name").Optional();
+        Map(m => m.FilePaths).Name("File Paths", "File paths", "FilePaths").Optional();
         Map(m => m.AudibleAAX).Name("Audible (AAX)").Optional();
 
-        // Optional Fields
         Map(m => m.NarratedBy).Name("Narrated By").Optional();
-        Map(m => m.PurchaseDate).Name("Purchase Date").TypeConverterOption.Format("yyyy-MM-dd", "MM/dd/yyyy", "M/d/yyyy");
         Map(m => m.Duration).Name("Duration").Optional();
-        Map(m => m.ReleaseDate).Name("Release Date").TypeConverterOption.Format("yyyy-MM-dd", "MM/dd/yyyy", "M/d/yyyy");
-        Map(m => m.AveRating).Name("Ave. Rating").Optional();
         Map(m => m.Genre).Name("Genre").Optional();
         Map(m => m.SeriesName).Name("Series Name").Optional();
         Map(m => m.SeriesSequence).Name("Series Sequence").Optional();
@@ -44,10 +45,13 @@ public sealed class AudiobookMap : ClassMap<OpenAudible>
         Map(m => m.Image).Name("Image").Optional();
         Map(m => m.M4B).Name("M4B").Optional();
         Map(m => m.MP3).Name("MP3").Optional();
-        Map(m => m.AYCE).Name("AYCE").TypeConverter<BooleanConverter>().Optional();
-        Map(m => m.RatingCount).Name("Rating Count").TypeConverter<Int32Converter>().Optional();
-
-        // **Newly Added Field**
         Map(m => m.PDF).Name("PDF").Optional();
+
+        // Typed columns get converters that fall back to a default instead of throwing.
+        Map(m => m.PurchaseDate).Name("Purchase Date").TypeConverter<LenientDateTimeConverter>().Optional();
+        Map(m => m.ReleaseDate).Name("Release Date").TypeConverter<LenientDateTimeConverter>().Optional();
+        Map(m => m.AveRating).Name("Ave. Rating", "Ave Rating", "Average Rating").TypeConverter<LenientDoubleConverter>().Optional();
+        Map(m => m.RatingCount).Name("Rating Count").TypeConverter<LenientInt32Converter>().Optional();
+        Map(m => m.AYCE).Name("AYCE").TypeConverter<LenientBooleanConverter>().Optional();
     }
 }

--- a/AudioFileSorter/Model/BookSortPlan.cs
+++ b/AudioFileSorter/Model/BookSortPlan.cs
@@ -1,0 +1,20 @@
+namespace AudioFileSorter.Model;
+
+/// <summary>
+/// The sanitised names a single book will be filed under. Built once per book and never mutated,
+/// so planning can be reasoned about (and tested) without touching the filesystem.
+/// </summary>
+public sealed record BookSortPlan
+{
+    /// <summary>Author folder name. Never null or empty.</summary>
+    public required string Author { get; init; }
+
+    /// <summary>Series folder name, or null when the book is not part of a series.</summary>
+    public string? SeriesName { get; init; }
+
+    /// <summary>Sequence within the series, or null. Only set when <see cref="SeriesName"/> is set.</summary>
+    public string? SeriesSequence { get; init; }
+
+    /// <summary>File name without extension. Never null or empty.</summary>
+    public required string FileStem { get; init; }
+}

--- a/AudioFileSorter/Model/LenientConverters.cs
+++ b/AudioFileSorter/Model/LenientConverters.cs
@@ -1,0 +1,107 @@
+using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
+
+namespace AudioFileSorter.Model;
+
+/// <summary>
+/// Converters that treat an unparseable cell as "no value" rather than as a reason to abandon the
+/// import. OpenAudible exports routinely contain blank ratings, blank dates and localised date
+/// formats, and losing a whole library to one odd cell is the single most common import failure.
+/// </summary>
+internal static class LenientConverters
+{
+    internal static readonly string[] DateFormats =
+    [
+        "yyyy-MM-dd", "yyyy/MM/dd", "MM/dd/yyyy", "M/d/yyyy", "dd/MM/yyyy", "d/M/yyyy",
+        "yyyy-MM-dd HH:mm:ss", "yyyy-MM-ddTHH:mm:ss", "dd.MM.yyyy"
+    ];
+}
+
+internal sealed class LenientDateTimeConverter : DefaultTypeConverter
+{
+    public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        var value = text.Trim();
+
+        if (DateTime.TryParseExact(value, LenientConverters.DateFormats, CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out var exact))
+        {
+            return exact;
+        }
+
+        if (DateTime.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            return parsed;
+        }
+
+        return DateTime.TryParse(value, CultureInfo.CurrentCulture, DateTimeStyles.None, out var localParsed)
+            ? localParsed
+            : null;
+    }
+}
+
+internal sealed class LenientDoubleConverter : DefaultTypeConverter
+{
+    public override object ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0d;
+        }
+
+        var value = text.Trim();
+
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) ||
+            double.TryParse(value, NumberStyles.Float, CultureInfo.CurrentCulture, out parsed))
+        {
+            return double.IsFinite(parsed) ? parsed : 0d;
+        }
+
+        return 0d;
+    }
+}
+
+internal sealed class LenientInt32Converter : DefaultTypeConverter
+{
+    public override object ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return 0;
+        }
+
+        var value = text.Trim().Replace(",", string.Empty).Replace(" ", string.Empty);
+
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var asDouble) &&
+               asDouble is >= int.MinValue and <= int.MaxValue
+            ? (int)asDouble
+            : 0;
+    }
+}
+
+internal sealed class LenientBooleanConverter : DefaultTypeConverter
+{
+    private static readonly string[] TruthyValues = ["true", "yes", "y", "1", "x"];
+
+    public override object ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        return Array.IndexOf(TruthyValues, text.Trim().ToLowerInvariant()) >= 0;
+    }
+}

--- a/AudioFileSorter/Model/OpenAudible.cs
+++ b/AudioFileSorter/Model/OpenAudible.cs
@@ -6,9 +6,9 @@ public class OpenAudible
     public string? Title { get; set; }
     public string? Author { get; set; }
     public string? NarratedBy { get; set; }
-    public DateTime PurchaseDate { get; set; }
+    public DateTime? PurchaseDate { get; set; }
     public string? Duration { get; set; }
-    public DateTime ReleaseDate { get; set; }
+    public DateTime? ReleaseDate { get; set; }
     public double AveRating { get; set; }
     public string? Genre { get; set; }
     public string? SeriesName { get; set; }

--- a/AudioFileSorter/Model/PlannedCopy.cs
+++ b/AudioFileSorter/Model/PlannedCopy.cs
@@ -1,0 +1,26 @@
+namespace AudioFileSorter.Model;
+
+/// <summary>
+/// One book's share of the work: the exact files to read and the exact paths to write.
+/// Produced by <see cref="SortPlanner"/> before any copying starts.
+/// </summary>
+public sealed record PlannedCopy
+{
+    public required OpenAudible Book { get; init; }
+
+    /// <summary>Human readable description used for progress reporting.</summary>
+    public required string Label { get; init; }
+
+    /// <summary>Folder to create before copying, or null when there is nothing to copy.</summary>
+    public string? TargetDirectory { get; init; }
+
+    public string? AudioSource { get; init; }
+    public string? AudioDestination { get; init; }
+    public string? PdfSource { get; init; }
+    public string? PdfDestination { get; init; }
+
+    /// <summary>Why this book is being skipped, or an issue worth surfacing. Null when all is well.</summary>
+    public string? Warning { get; init; }
+
+    public bool HasWork => TargetDirectory is not null && (AudioDestination is not null || PdfDestination is not null);
+}

--- a/AudioFileSorter/Model/SortOptions.cs
+++ b/AudioFileSorter/Model/SortOptions.cs
@@ -1,0 +1,74 @@
+namespace AudioFileSorter.Model;
+
+/// <summary>
+/// How an already-present destination file is checked against its source before the organiser
+/// decides whether to replace it.
+/// </summary>
+public enum FileComparisonMode
+{
+    /// <summary>
+    /// Size plus three sampled 4 KB chunks (start, middle, end). Fast enough to run over a large
+    /// library on every sort, and it catches any re-release that changed the file's length — which
+    /// is nearly all of them. It can miss an edit that kept the exact same size and left those
+    /// three windows untouched.
+    /// </summary>
+    Quick = 0,
+
+    /// <summary>
+    /// Byte-for-byte comparison of the whole file. Replaces the destination whenever the source
+    /// differs at all, at the cost of reading both files in full. The right choice when authors
+    /// re-issue books and you would rather pay the I/O than keep a stale copy.
+    /// </summary>
+    Full = 1
+}
+
+/// <summary>Per-run settings for a sort.</summary>
+public sealed record SortOptions
+{
+    /// <summary>The settings used when a caller does not supply any.</summary>
+    public static readonly SortOptions Default = new();
+
+    /// <summary>How to decide whether an existing destination file is out of date.</summary>
+    public FileComparisonMode ComparisonMode { get; init; } = FileComparisonMode.Quick;
+
+    /// <summary>
+    /// Parses a mode from configuration or a request body. A missing or blank value means "use the
+    /// default", so callers can treat null as valid; anything unrecognised is rejected rather than
+    /// silently downgraded, since quietly running the wrong mode is exactly what this setting
+    /// exists to prevent.
+    /// </summary>
+    public static bool TryParseComparisonMode(string? value, out FileComparisonMode mode)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            mode = Default.ComparisonMode;
+            return true;
+        }
+
+        switch (value.Trim().ToLowerInvariant())
+        {
+            case "quick":
+            case "fast":
+            case "sampled":
+                mode = FileComparisonMode.Quick;
+                return true;
+
+            case "full":
+            case "verify":
+            case "exact":
+            case "content":
+                mode = FileComparisonMode.Full;
+                return true;
+
+            default:
+                mode = Default.ComparisonMode;
+                return false;
+        }
+    }
+
+    /// <summary>The canonical spelling of a mode, as used by the API and the UI.</summary>
+    public static string ToWireValue(FileComparisonMode mode)
+    {
+        return mode == FileComparisonMode.Full ? "full" : "quick";
+    }
+}

--- a/AudioFileSorter/Model/SortProgress.cs
+++ b/AudioFileSorter/Model/SortProgress.cs
@@ -6,6 +6,9 @@ public class SortProgressInfo
     public int TotalBooks { get; set; }
     public int CopiedBooks { get; set; }
 
+    /// <summary>Books where an out-of-date file at the destination was replaced. Part of <see cref="CopiedBooks"/>.</summary>
+    public int UpdatedBooks { get; set; }
+
     /// <summary>Books that needed no work: already up to date, or with no matching source file.</summary>
     public int SkippedBooks { get; set; }
 

--- a/AudioFileSorter/Model/SortProgress.cs
+++ b/AudioFileSorter/Model/SortProgress.cs
@@ -5,6 +5,16 @@ public class SortProgressInfo
     public int CurrentBook { get; set; }
     public int TotalBooks { get; set; }
     public int CopiedBooks { get; set; }
+
+    /// <summary>Books that needed no work: already up to date, or with no matching source file.</summary>
+    public int SkippedBooks { get; set; }
+
+    /// <summary>Books that could not be processed because of an error.</summary>
+    public int FailedBooks { get; set; }
+
+    /// <summary>Number of problems recorded so far. Details are written to the backend log.</summary>
+    public int WarningCount { get; set; }
+
     public string? CurrentTitle { get; set; }
     public double Percentage { get; set; }
     public bool IsComplete { get; set; }

--- a/AudioFileSorter/Model/SortSummary.cs
+++ b/AudioFileSorter/Model/SortSummary.cs
@@ -5,8 +5,14 @@ public sealed class SortSummary
 {
     public int TotalBooks { get; init; }
 
-    /// <summary>Books for which at least one file was written.</summary>
+    /// <summary>Books for which at least one file was written, whether new or replaced.</summary>
     public int CopiedBooks { get; init; }
+
+    /// <summary>
+    /// Books where a file already at the destination was found to be out of date and replaced.
+    /// A subset of <see cref="CopiedBooks"/>.
+    /// </summary>
+    public int UpdatedBooks { get; init; }
 
     /// <summary>Books that were already up to date, or had no file to copy.</summary>
     public int SkippedBooks { get; init; }

--- a/AudioFileSorter/Model/SortSummary.cs
+++ b/AudioFileSorter/Model/SortSummary.cs
@@ -1,0 +1,24 @@
+namespace AudioFileSorter.Model;
+
+/// <summary>Outcome of a completed (or cancelled) sort run.</summary>
+public sealed class SortSummary
+{
+    public int TotalBooks { get; init; }
+
+    /// <summary>Books for which at least one file was written.</summary>
+    public int CopiedBooks { get; init; }
+
+    /// <summary>Books that were already up to date, or had no file to copy.</summary>
+    public int SkippedBooks { get; init; }
+
+    /// <summary>Books that could not be processed because of an error.</summary>
+    public int FailedBooks { get; init; }
+
+    public bool IsCanceled { get; init; }
+
+    /// <summary>A capped sample of the problems encountered, in the order they occurred.</summary>
+    public IReadOnlyList<string> Warnings { get; init; } = [];
+
+    /// <summary>Total number of warnings, which may be larger than <see cref="Warnings"/>.</summary>
+    public int WarningCount { get; init; }
+}

--- a/AudioFileSorter/PathSanitizer.cs
+++ b/AudioFileSorter/PathSanitizer.cs
@@ -1,0 +1,274 @@
+using System.Text;
+
+namespace AudioFileSorter;
+
+/// <summary>
+/// Turns free-form book metadata into path segments that are safe on every filesystem the
+/// organiser writes to. Sanitising against the strictest rule set (Windows) on every platform
+/// keeps a library portable: a destination folder is very often an SMB share or an external
+/// drive that is later read from a different operating system.
+/// </summary>
+public static class PathSanitizer
+{
+    /// <summary>Maximum number of characters allowed in a single path segment.</summary>
+    public const int MaxSegmentLength = 200;
+
+    /// <summary>Maximum number of UTF-8 bytes allowed in a single path segment.</summary>
+    public const int MaxSegmentBytes = 200;
+
+    private static readonly string[] PlaceholderValues = ["unknown", "n/a", "na", "none", "null"];
+    private static readonly string[] LeadingArticles = ["the ", "a ", "an "];
+    private static readonly string[] SeriesDecorators = [" series", " saga", " cycle"];
+
+    // Invalid on Windows even when the app is running on Linux or macOS.
+    private static readonly char[] CrossPlatformInvalidChars = ['<', '>', ':', '"', '/', '\\', '|', '?', '*'];
+    private static readonly char[] PlatformInvalidChars = Path.GetInvalidFileNameChars();
+    private static readonly HashSet<string> ReservedDeviceNames = BuildReservedDeviceNames();
+
+    private static readonly StringComparison PathComparison =
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    /// <summary>
+    /// Converts a metadata value into a single safe path segment, or <c>null</c> when the value
+    /// carries no usable information (empty, a placeholder such as "Unknown", or nothing but
+    /// characters that had to be stripped).
+    /// </summary>
+    public static string? SanitizeSegment(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var builder = new StringBuilder(value.Length);
+        foreach (var ch in value)
+        {
+            if (char.IsControl(ch))
+            {
+                // Control characters (including embedded newlines from multi-line CSV cells)
+                // become a space so words do not get glued together.
+                builder.Append(' ');
+                continue;
+            }
+
+            if (Array.IndexOf(CrossPlatformInvalidChars, ch) >= 0 ||
+                Array.IndexOf(PlatformInvalidChars, ch) >= 0)
+            {
+                continue;
+            }
+
+            builder.Append(ch);
+        }
+
+        var normalized = CollapseWhitespace(builder.ToString());
+        normalized = TrimSegment(normalized);
+
+        if (normalized.Length == 0 || normalized is "." or ".." || IsPlaceholder(normalized))
+        {
+            return null;
+        }
+
+        normalized = TrimSegment(Truncate(normalized, MaxSegmentLength, MaxSegmentBytes));
+        if (normalized.Length == 0)
+        {
+            return null;
+        }
+
+        // CON, LPT1 and friends cannot be used as a file or folder name on Windows, with or
+        // without an extension, and fail with a confusing "path not supported" error.
+        return IsReservedDeviceName(normalized) ? $"_{normalized}" : normalized;
+    }
+
+    /// <summary>
+    /// Sanitises a value, falling back to the first usable alternative and finally to
+    /// <paramref name="fallback"/>.
+    /// </summary>
+    public static string SanitizeSegmentOrFallback(string fallback, params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            var sanitized = SanitizeSegment(value);
+            if (sanitized is not null)
+            {
+                return sanitized;
+            }
+        }
+
+        return fallback;
+    }
+
+    public static bool IsPlaceholder(string value)
+    {
+        return Array.IndexOf(PlaceholderValues, value.Trim().ToLowerInvariant()) >= 0;
+    }
+
+    /// <summary>
+    /// Key used to decide whether two author (or file) names refer to the same thing, so that
+    /// "J.K. Rowling", "JK Rowling" and "J K Rowling" all land in one folder.
+    /// </summary>
+    public static string NormalizeComparisonKey(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+        return new string(normalized.Where(char.IsLetterOrDigit).ToArray());
+    }
+
+    /// <summary>
+    /// Comparison key for series names, ignoring a leading article and a trailing decorator so
+    /// that "The Wheel of Time" and "Wheel of Time Series" resolve to the same folder.
+    /// </summary>
+    public static string NormalizeSeriesKey(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Trim().ToLowerInvariant();
+
+        foreach (var article in LeadingArticles)
+        {
+            if (normalized.StartsWith(article, StringComparison.Ordinal))
+            {
+                normalized = normalized[article.Length..];
+                break;
+            }
+        }
+
+        foreach (var decorator in SeriesDecorators)
+        {
+            if (normalized.EndsWith(decorator, StringComparison.Ordinal))
+            {
+                normalized = normalized[..^decorator.Length];
+                break;
+            }
+        }
+
+        return new string(normalized.Where(char.IsLetterOrDigit).ToArray());
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="candidate"/> resolves to a location strictly inside
+    /// <paramref name="root"/>. The last line of defence against a metadata value escaping the
+    /// destination folder.
+    /// </summary>
+    public static bool IsWithin(string root, string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(root) || string.IsNullOrWhiteSpace(candidate))
+        {
+            return false;
+        }
+
+        string fullRoot;
+        string fullCandidate;
+        try
+        {
+            fullRoot = Path.GetFullPath(root);
+            fullCandidate = Path.GetFullPath(candidate);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return false;
+        }
+
+        if (fullRoot.Length == 0)
+        {
+            return false;
+        }
+
+        if (fullRoot[^1] != Path.DirectorySeparatorChar)
+        {
+            fullRoot += Path.DirectorySeparatorChar;
+        }
+
+        return fullCandidate.Length > fullRoot.Length &&
+               fullCandidate.StartsWith(fullRoot, PathComparison);
+    }
+
+    /// <summary>
+    /// Shortens a value so it fits within both the character and UTF-8 byte budget of a path
+    /// segment, without splitting a surrogate pair.
+    /// </summary>
+    public static string Truncate(string value, int maxChars, int maxBytes)
+    {
+        var result = value.Length > maxChars ? value[..maxChars] : value;
+
+        if (result.Length > 0 && char.IsHighSurrogate(result[^1]))
+        {
+            result = result[..^1];
+        }
+
+        while (result.Length > 0 && Encoding.UTF8.GetByteCount(result) > maxBytes)
+        {
+            result = result[..^1];
+            if (result.Length > 0 && char.IsHighSurrogate(result[^1]))
+            {
+                result = result[..^1];
+            }
+        }
+
+        return result;
+    }
+
+    private static string TrimSegment(string value)
+    {
+        // Windows silently drops trailing dots and spaces, which turns "Vol. 2 ." into a name
+        // that never matches on a later run.
+        return value.Trim().TrimEnd('.', ' ').Trim();
+    }
+
+    private static string CollapseWhitespace(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        var pendingSpace = false;
+
+        foreach (var ch in value)
+        {
+            if (char.IsWhiteSpace(ch))
+            {
+                pendingSpace = builder.Length > 0;
+                continue;
+            }
+
+            if (pendingSpace)
+            {
+                builder.Append(' ');
+                pendingSpace = false;
+            }
+
+            builder.Append(ch);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool IsReservedDeviceName(string value)
+    {
+        var stem = value;
+        var dotIndex = stem.IndexOf('.');
+        if (dotIndex > 0)
+        {
+            stem = stem[..dotIndex];
+        }
+
+        return ReservedDeviceNames.Contains(stem.TrimEnd(' '));
+    }
+
+    private static HashSet<string> BuildReservedDeviceNames()
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "CON", "PRN", "AUX", "NUL" };
+        for (var i = 1; i <= 9; i++)
+        {
+            names.Add($"COM{i}");
+            names.Add($"LPT{i}");
+        }
+
+        return names;
+    }
+}

--- a/AudioFileSorter/SortAudioFiles.cs
+++ b/AudioFileSorter/SortAudioFiles.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Threading;
@@ -13,6 +14,7 @@ public class FileSorter
 {
     private const int MaxReportedWarnings = 200;
     private const int CopyBufferSize = 81920;
+    private const int ComparisonBufferSize = 131072;
     private const string PartialFileSuffix = ".oabo-partial";
 
     private static readonly object ConsoleLock = new();
@@ -23,6 +25,7 @@ public class FileSorter
     /// <param name="source">Source folder containing audio files.</param>
     /// <param name="destination">Destination folder to sort files into.</param>
     /// <param name="openAudibles">List of audiobook metadata. Never modified.</param>
+    /// <param name="options">Per-run settings. Defaults to <see cref="SortOptions.Default"/>.</param>
     /// <param name="progress">Optional progress reporter.</param>
     /// <param name="cancellationToken">Token used to abort the run.</param>
     /// <exception cref="ArgumentException">A required path was not supplied.</exception>
@@ -32,10 +35,13 @@ public class FileSorter
         string? source,
         string? destination,
         List<OpenAudible> openAudibles,
+        SortOptions? options = null,
         IProgress<SortProgressInfo>? progress = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(openAudibles);
+
+        var comparisonMode = (options ?? SortOptions.Default).ComparisonMode;
 
         // These used to be logged and swallowed, which left the UI waiting for a run that was
         // never going to report anything.
@@ -85,8 +91,11 @@ public class FileSorter
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        WriteLine($"Sorting {totalBooks} books using the {DescribeMode(comparisonMode)} update check.");
+
         var progressCount = 0;
         var copiedBooks = 0;
+        var updatedBooks = 0;
         var skippedBooks = 0;
         var failedBooks = 0;
         var maxLineLength = 0;
@@ -99,20 +108,22 @@ public class FileSorter
 
         await Parallel.ForEachAsync(planned, parallelOptions, async (item, ct) =>
         {
-            var copiedAnything = false;
-
             try
             {
                 ct.ThrowIfCancellationRequested();
-                copiedAnything = await ProcessPlannedCopy(item, ct);
+                var outcome = await ProcessPlannedCopy(item, comparisonMode, ct);
 
-                if (copiedAnything)
+                if (outcome == CopyOutcome.Skipped)
                 {
-                    Interlocked.Increment(ref copiedBooks);
+                    Interlocked.Increment(ref skippedBooks);
                 }
                 else
                 {
-                    Interlocked.Increment(ref skippedBooks);
+                    Interlocked.Increment(ref copiedBooks);
+                    if (outcome == CopyOutcome.Updated)
+                    {
+                        Interlocked.Increment(ref updatedBooks);
+                    }
                 }
             }
             catch (OperationCanceledException)
@@ -134,6 +145,7 @@ public class FileSorter
                 CurrentBook = currentProgress,
                 TotalBooks = totalBooks,
                 CopiedBooks = currentCopied,
+                UpdatedBooks = Volatile.Read(ref updatedBooks),
                 SkippedBooks = Volatile.Read(ref skippedBooks),
                 FailedBooks = Volatile.Read(ref failedBooks),
                 CurrentTitle = item.Label,
@@ -146,6 +158,7 @@ public class FileSorter
         {
             TotalBooks = totalBooks,
             CopiedBooks = copiedBooks,
+            UpdatedBooks = updatedBooks,
             SkippedBooks = skippedBooks,
             FailedBooks = failedBooks,
             Warnings = warnings.ToArray(),
@@ -157,6 +170,7 @@ public class FileSorter
             CurrentBook = totalBooks,
             TotalBooks = totalBooks,
             CopiedBooks = summary.CopiedBooks,
+            UpdatedBooks = summary.UpdatedBooks,
             SkippedBooks = summary.SkippedBooks,
             FailedBooks = summary.FailedBooks,
             Percentage = 100,
@@ -164,40 +178,89 @@ public class FileSorter
             WarningCount = summary.WarningCount
         });
 
-        WriteLine($"Sorting complete. Copied {summary.CopiedBooks}, skipped {summary.SkippedBooks}, failed {summary.FailedBooks} of {totalBooks}.");
+        WriteLine(
+            $"Sorting complete. Copied {summary.CopiedBooks} (of which {summary.UpdatedBooks} updated), " +
+            $"skipped {summary.SkippedBooks}, failed {summary.FailedBooks} of {totalBooks}.");
         return summary;
     }
 
-    private static async Task<bool> ProcessPlannedCopy(PlannedCopy item, CancellationToken cancellationToken)
+    /// <summary>What a single file, or a whole book, needed.</summary>
+    private enum CopyOutcome
+    {
+        /// <summary>Already up to date, or nothing to copy.</summary>
+        Skipped = 0,
+
+        /// <summary>Written where nothing was before.</summary>
+        Created = 1,
+
+        /// <summary>An existing, out-of-date file was replaced.</summary>
+        Updated = 2
+    }
+
+    private static async Task<CopyOutcome> ProcessPlannedCopy(
+        PlannedCopy item,
+        FileComparisonMode comparisonMode,
+        CancellationToken cancellationToken)
     {
         if (!item.HasWork)
         {
-            return false;
+            return CopyOutcome.Skipped;
         }
 
         Directory.CreateDirectory(item.TargetDirectory!);
 
-        var copiedAudio = await CopyIfNeededAsync(item.AudioSource, item.AudioDestination, cancellationToken);
-        var copiedPdf = await CopyIfNeededAsync(item.PdfSource, item.PdfDestination, cancellationToken);
-        return copiedAudio || copiedPdf;
+        var audio = await CopyIfNeededAsync(item.AudioSource, item.AudioDestination, comparisonMode, cancellationToken);
+        var pdf = await CopyIfNeededAsync(item.PdfSource, item.PdfDestination, comparisonMode, cancellationToken);
+
+        // A book counts as updated when any of its files replaced an existing one; a book whose
+        // audio is new but whose PDF was already there is simply a copy.
+        if (audio == CopyOutcome.Updated || pdf == CopyOutcome.Updated)
+        {
+            return CopyOutcome.Updated;
+        }
+
+        return audio == CopyOutcome.Created || pdf == CopyOutcome.Created
+            ? CopyOutcome.Created
+            : CopyOutcome.Skipped;
     }
 
-    private static async Task<bool> CopyIfNeededAsync(string? sourceFile, string? destinationFile, CancellationToken cancellationToken)
+    private static async Task<CopyOutcome> CopyIfNeededAsync(
+        string? sourceFile,
+        string? destinationFile,
+        FileComparisonMode comparisonMode,
+        CancellationToken cancellationToken)
     {
         if (sourceFile is null || destinationFile is null)
         {
-            return false;
+            return CopyOutcome.Skipped;
         }
 
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (File.Exists(destinationFile) && await AreFilesSameAsync(sourceFile, destinationFile, cancellationToken))
+        var destinationExists = File.Exists(destinationFile);
+        if (destinationExists && await IsDestinationUpToDateAsync(sourceFile, destinationFile, comparisonMode, cancellationToken))
         {
-            return false;
+            return CopyOutcome.Skipped;
         }
 
         await CopyFileAtomicAsync(sourceFile, destinationFile, cancellationToken);
-        return true;
+        return destinationExists ? CopyOutcome.Updated : CopyOutcome.Created;
+    }
+
+    /// <summary>
+    /// Decides whether the file already at the destination still matches its source. Returning
+    /// false means "replace it", so every uncertain case has to answer false: a book the user
+    /// re-downloaded must not stay stale because a check could not make up its mind.
+    /// </summary>
+    private static Task<bool> IsDestinationUpToDateAsync(
+        string sourceFile,
+        string destinationFile,
+        FileComparisonMode comparisonMode,
+        CancellationToken cancellationToken)
+    {
+        return comparisonMode == FileComparisonMode.Full
+            ? AreFilesIdenticalAsync(sourceFile, destinationFile, cancellationToken)
+            : AreFilesSameAsync(sourceFile, destinationFile, cancellationToken);
     }
 
     /// <summary>
@@ -301,6 +364,88 @@ public class FileSorter
         }
     }
 
+    /// <summary>
+    /// Byte-for-byte comparison of two files. Used by <see cref="FileComparisonMode.Full"/>, where
+    /// the point is to notice a re-released book that happens to be exactly the same size as the
+    /// copy already on disk — something the sampled check cannot see.
+    /// </summary>
+    private static async Task<bool> AreFilesIdenticalAsync(string filePath1, string filePath2, CancellationToken cancellationToken)
+    {
+        byte[]? buffer1 = null;
+        byte[]? buffer2 = null;
+
+        try
+        {
+            var fileInfo1 = new FileInfo(filePath1);
+            var fileInfo2 = new FileInfo(filePath2);
+
+            if (!fileInfo1.Exists || !fileInfo2.Exists || fileInfo1.Length != fileInfo2.Length)
+            {
+                return false;
+            }
+
+            if (fileInfo1.Length == 0)
+            {
+                return true;
+            }
+
+            buffer1 = ArrayPool<byte>.Shared.Rent(ComparisonBufferSize);
+            buffer2 = ArrayPool<byte>.Shared.Rent(ComparisonBufferSize);
+
+            await using var stream1 = new FileStream(
+                filePath1, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, ComparisonBufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+            await using var stream2 = new FileStream(
+                filePath2, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, ComparisonBufferSize,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+            while (true)
+            {
+                var read1 = await stream1.ReadAtLeastAsync(
+                    buffer1.AsMemory(0, ComparisonBufferSize), ComparisonBufferSize, throwOnEndOfStream: false, cancellationToken);
+                var read2 = await stream2.ReadAtLeastAsync(
+                    buffer2.AsMemory(0, ComparisonBufferSize), ComparisonBufferSize, throwOnEndOfStream: false, cancellationToken);
+
+                if (read1 != read2)
+                {
+                    // The lengths matched a moment ago, so one of the files is being written to
+                    // right now. Treat it as different and copy again on this or the next run.
+                    return false;
+                }
+
+                if (read1 == 0)
+                {
+                    return true;
+                }
+
+                if (!buffer1.AsSpan(0, read1).SequenceEqual(buffer2.AsSpan(0, read2)))
+                {
+                    return false;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return false; // Assume the files differ so the copy is retried.
+        }
+        finally
+        {
+            if (buffer1 is not null)
+            {
+                ArrayPool<byte>.Shared.Return(buffer1);
+            }
+
+            if (buffer2 is not null)
+            {
+                ArrayPool<byte>.Shared.Return(buffer2);
+            }
+        }
+    }
+
     private static IEnumerable<long> GetSampleOffsets(long length, int chunkSize)
     {
         yield return 0;
@@ -317,6 +462,11 @@ public class FileSorter
         }
 
         yield return Math.Max(0, length - chunkSize);
+    }
+
+    private static string DescribeMode(FileComparisonMode mode)
+    {
+        return mode == FileComparisonMode.Full ? "full (byte-for-byte)" : "quick (size and sampled contents)";
     }
 
     internal static double CalculatePercentage(int current, int total)

--- a/AudioFileSorter/SortAudioFiles.cs
+++ b/AudioFileSorter/SortAudioFiles.cs
@@ -1,63 +1,119 @@
-﻿using System.IO;
-using System.Security.Cryptography;
-using System.Text.RegularExpressions;
+using System.Collections.Concurrent;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using AudioFileSorter.Model;
 
 namespace AudioFileSorter;
 
+/// <summary>
+/// Copies an OpenAudible library into an Author / Series / Book folder structure.
+/// </summary>
 public class FileSorter
 {
+    private const int MaxReportedWarnings = 200;
+    private const int CopyBufferSize = 81920;
+    private const string PartialFileSuffix = ".oabo-partial";
+
     private static readonly object ConsoleLock = new();
-    private static readonly string[] PlaceholderValues = ["unknown", "n/a", "na", "none", "null"];
-    private static readonly string[] LeadingArticles = ["the ", "a ", "an "];
-    private static readonly string[] SeriesDecorators = [" series", " saga", " cycle"];
-    private static readonly string[] ContributorDescriptors = ["foreword", "afterword", "editor", "contributor", "adaptation", "music", "translator", "translatoreditor", "introduction", "preface", "illustrator"];
-    private static readonly string[] KnownNonAuthorSegments = ["the great courses", "crystal lake publishing", "crystal lake audio"];
-    private static readonly Regex SequenceValueRegex = new(@"(?<value>\d+(?:\.\d+)?(?:-\d+(?:\.\d+)?)?)", RegexOptions.Compiled);
 
     /// <summary>
-    /// Sorts Open Audible books into the provided destination path in parallel.
+    /// Sorts Open Audible books into the provided destination path.
     /// </summary>
     /// <param name="source">Source folder containing audio files.</param>
     /// <param name="destination">Destination folder to sort files into.</param>
-    /// <param name="openAudibles">List of audiobook metadata.</param>
+    /// <param name="openAudibles">List of audiobook metadata. Never modified.</param>
     /// <param name="progress">Optional progress reporter.</param>
-    public async Task SortAudioFiles(
+    /// <param name="cancellationToken">Token used to abort the run.</param>
+    /// <exception cref="ArgumentException">A required path was not supplied.</exception>
+    /// <exception cref="DirectoryNotFoundException">The source folder does not exist.</exception>
+    /// <exception cref="IOException">The destination folder could not be created.</exception>
+    public async Task<SortSummary> SortAudioFiles(
         string? source,
         string? destination,
         List<OpenAudible> openAudibles,
         IProgress<SortProgressInfo>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(source) || string.IsNullOrWhiteSpace(destination))
+        ArgumentNullException.ThrowIfNull(openAudibles);
+
+        // These used to be logged and swallowed, which left the UI waiting for a run that was
+        // never going to report anything.
+        if (string.IsNullOrWhiteSpace(source))
         {
-            Console.WriteLine("Error: Source or destination path is missing.");
-            return;
+            throw new ArgumentException("Source path is required.", nameof(source));
         }
 
-        var progressCount = 0;
-        var copyBooks = 0;
+        if (string.IsNullOrWhiteSpace(destination))
+        {
+            throw new ArgumentException("Destination path is required.", nameof(destination));
+        }
+
+        if (!Directory.Exists(source))
+        {
+            throw new DirectoryNotFoundException($"Source folder not found: {source}");
+        }
+
+        try
+        {
+            Directory.CreateDirectory(destination);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or ArgumentException)
+        {
+            throw new IOException($"Destination folder is not writable: {destination}. {ex.Message}", ex);
+        }
+
         var totalBooks = openAudibles.Count;
+        var warnings = new ConcurrentQueue<string>();
+        var warningCount = 0;
+
+        if (totalBooks == 0)
+        {
+            progress?.Report(new SortProgressInfo { Percentage = 100, IsComplete = true });
+            WriteLine("No books to sort.");
+            return new SortSummary { Warnings = [] };
+        }
+
+        var planned = new SortPlanner().Plan(openAudibles, source, Path.GetFullPath(destination));
+        foreach (var item in planned)
+        {
+            if (item.Warning is not null)
+            {
+                RecordWarning(warnings, ref warningCount, item.Warning);
+            }
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var progressCount = 0;
+        var copiedBooks = 0;
+        var skippedBooks = 0;
+        var failedBooks = 0;
         var maxLineLength = 0;
-        
-        var maxParallelism = Math.Max(1, Environment.ProcessorCount / 4); // speed up transfers for high end cpus
+
         var parallelOptions = new ParallelOptions
         {
-            MaxDegreeOfParallelism = maxParallelism,
+            MaxDegreeOfParallelism = GetMaxParallelism(),
             CancellationToken = cancellationToken
         };
-        
-        
-        // Run parallel sorting operations
-        await Parallel.ForEachAsync(openAudibles, parallelOptions, async (audioFile, ct) =>
+
+        await Parallel.ForEachAsync(planned, parallelOptions, async (item, ct) =>
         {
+            var copiedAnything = false;
+
             try
             {
                 ct.ThrowIfCancellationRequested();
-                var copied = await ProcessAudioFile(audioFile, source, destination, ct);
-                if (copied) Interlocked.Increment(ref copyBooks);
+                copiedAnything = await ProcessPlannedCopy(item, ct);
+
+                if (copiedAnything)
+                {
+                    Interlocked.Increment(ref copiedBooks);
+                }
+                else
+                {
+                    Interlocked.Increment(ref skippedBooks);
+                }
             }
             catch (OperationCanceledException)
             {
@@ -65,453 +121,135 @@ public class FileSorter
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"\nError processing {audioFile.Filename}: {ex.Message}");
+                Interlocked.Increment(ref failedBooks);
+                RecordWarning(warnings, ref warningCount, $"Error processing {item.Book.Filename ?? item.Label}: {ex.Message}");
             }
 
             var currentProgress = Interlocked.Increment(ref progressCount);
-            var progressLabel = BuildProgressLabel(audioFile);
-            UpdateProgress(currentProgress, totalBooks, copyBooks, progressLabel, ref maxLineLength);
+            var currentCopied = Volatile.Read(ref copiedBooks);
+            UpdateProgress(currentProgress, totalBooks, currentCopied, item.Label, ref maxLineLength);
 
             progress?.Report(new SortProgressInfo
             {
                 CurrentBook = currentProgress,
                 TotalBooks = totalBooks,
-                CopiedBooks = copyBooks,
-                CurrentTitle = progressLabel,
-                Percentage = Math.Round((double)currentProgress / totalBooks * 100, 2)
+                CopiedBooks = currentCopied,
+                SkippedBooks = Volatile.Read(ref skippedBooks),
+                FailedBooks = Volatile.Read(ref failedBooks),
+                CurrentTitle = item.Label,
+                Percentage = CalculatePercentage(currentProgress, totalBooks),
+                WarningCount = Volatile.Read(ref warningCount)
             });
         });
+
+        var summary = new SortSummary
+        {
+            TotalBooks = totalBooks,
+            CopiedBooks = copiedBooks,
+            SkippedBooks = skippedBooks,
+            FailedBooks = failedBooks,
+            Warnings = warnings.ToArray(),
+            WarningCount = warningCount
+        };
 
         progress?.Report(new SortProgressInfo
         {
             CurrentBook = totalBooks,
             TotalBooks = totalBooks,
-            CopiedBooks = copyBooks,
+            CopiedBooks = summary.CopiedBooks,
+            SkippedBooks = summary.SkippedBooks,
+            FailedBooks = summary.FailedBooks,
             Percentage = 100,
-            IsComplete = true
+            IsComplete = true,
+            WarningCount = summary.WarningCount
         });
 
-        Console.WriteLine("\nSorting complete.");
+        WriteLine($"Sorting complete. Copied {summary.CopiedBooks}, skipped {summary.SkippedBooks}, failed {summary.FailedBooks} of {totalBooks}.");
+        return summary;
     }
 
-    private static async Task<bool> ProcessAudioFile(OpenAudible audioFile, string source, string destination, CancellationToken cancellationToken)
+    private static async Task<bool> ProcessPlannedCopy(PlannedCopy item, CancellationToken cancellationToken)
     {
-        // Sanitize file names to prevent invalid path issues
-        audioFile.Author = ResolveAuthorDirectoryName(destination, SanitizeAuthorName(audioFile.Author));
-        audioFile.SeriesName = SanitizeOptionalFileName(audioFile.SeriesName);
-        audioFile.SeriesSequence = SanitizeSeriesSequence(audioFile.SeriesSequence);
-        audioFile.ShortTitle = SanitizeRequiredFileName(audioFile.ShortTitle);
-        audioFile.Title = SanitizeRequiredFileName(audioFile.Title);
-
-        if (string.IsNullOrWhiteSpace(audioFile.Author))
+        if (!item.HasWork)
         {
-            Console.WriteLine($"\nWarning: Missing author for {audioFile.Filename}");
             return false;
         }
 
-        var directory = CreateTargetDirectory(destination, audioFile);
-        var copiedAudio = await CopyAudioFileAsync(audioFile, source, directory, cancellationToken);
-        var copiedPdf = await CopyPdfCompanionAsync(audioFile, source, directory, cancellationToken);
+        Directory.CreateDirectory(item.TargetDirectory!);
+
+        var copiedAudio = await CopyIfNeededAsync(item.AudioSource, item.AudioDestination, cancellationToken);
+        var copiedPdf = await CopyIfNeededAsync(item.PdfSource, item.PdfDestination, cancellationToken);
         return copiedAudio || copiedPdf;
     }
 
-    private static string CreateTargetDirectory(string destination, OpenAudible audioFile)
+    private static async Task<bool> CopyIfNeededAsync(string? sourceFile, string? destinationFile, CancellationToken cancellationToken)
     {
-        var authorPath = Path.Combine(destination, audioFile.Author ?? throw new InvalidOperationException());
-        var directory = Directory.CreateDirectory(authorPath).FullName;
-
-        if (!string.IsNullOrWhiteSpace(audioFile.SeriesName))
-        {
-            var seriesDirectory = ResolveSeriesDirectoryName(directory, audioFile.SeriesName);
-            directory = Path.Combine(directory, seriesDirectory);
-            Directory.CreateDirectory(directory);
-
-            if (!string.IsNullOrWhiteSpace(audioFile.SeriesSequence))
-            {
-                directory = Path.Combine(directory, $"Book {audioFile.SeriesSequence}");
-                Directory.CreateDirectory(directory);
-            }
-        }
-
-        return directory;
-    }
-
-    private static async Task<bool> CopyAudioFileAsync(OpenAudible audioFile, string source, string targetDirectory, CancellationToken cancellationToken)
-    {
-        var fileExtension = GetAudioFileExtension(audioFile);
-        if (fileExtension == null) return false;
-
-        var sourceFile = Path.Combine(source, $"{audioFile.Filename}{fileExtension}");
-        var destinationFile = Path.Combine(targetDirectory, $"{audioFile.ShortTitle}{fileExtension}");
-
-        if (!File.Exists(sourceFile))
-        {
-            Console.WriteLine($"\nWarning: Source file missing: {sourceFile}");
-            return false;
-        }
-
-        try
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (!File.Exists(destinationFile) || !await AreFilesSameAsync(sourceFile, destinationFile, cancellationToken))
-            {
-                await CopyFileAsync(sourceFile, destinationFile, cancellationToken);
-                // File.Copy(sourceFile, destinationFile, true);
-                return true;
-            }
-        }
-        catch (OperationCanceledException)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"\nError copying {sourceFile}: {ex.Message}");
-        }
-
-        return false;
-    }
-
-    private static async Task<bool> CopyPdfCompanionAsync(OpenAudible audioFile, string source, string targetDirectory, CancellationToken cancellationToken)
-    {
-        var sourcePdf = ResolvePdfSourcePath(audioFile, source);
-        if (sourcePdf == null)
+        if (sourceFile is null || destinationFile is null)
         {
             return false;
         }
 
-        var destinationPdf = Path.Combine(targetDirectory, $"{audioFile.ShortTitle}.pdf");
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (File.Exists(destinationFile) && await AreFilesSameAsync(sourceFile, destinationFile, cancellationToken))
+        {
+            return false;
+        }
+
+        await CopyFileAtomicAsync(sourceFile, destinationFile, cancellationToken);
+        return true;
+    }
+
+    /// <summary>
+    /// Copies through a temporary file in the destination folder and renames it into place, so an
+    /// interrupted run (cancel, crash, full disk) can never leave a half written book behind that
+    /// a later run would mistake for a complete one.
+    /// </summary>
+    private static async Task CopyFileAtomicAsync(string sourceFile, string destinationFile, CancellationToken cancellationToken)
+    {
+        var partialFile = destinationFile + PartialFileSuffix;
 
         try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (!File.Exists(destinationPdf) || !await AreFilesSameAsync(sourcePdf, destinationPdf, cancellationToken))
+            await using (var sourceStream = new FileStream(
+                             sourceFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, CopyBufferSize,
+                             FileOptions.Asynchronous | FileOptions.SequentialScan))
+            await using (var destinationStream = new FileStream(
+                             partialFile, FileMode.Create, FileAccess.Write, FileShare.None, CopyBufferSize,
+                             FileOptions.Asynchronous | FileOptions.SequentialScan))
             {
-                await CopyFileAsync(sourcePdf, destinationPdf, cancellationToken);
-                return true;
+                await sourceStream.CopyToAsync(destinationStream, CopyBufferSize, cancellationToken);
+                await destinationStream.FlushAsync(cancellationToken);
             }
+
+            File.Move(partialFile, destinationFile, overwrite: true);
         }
-        catch (OperationCanceledException)
+        catch
         {
+            TryDelete(partialFile);
             throw;
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"\nError copying {sourcePdf}: {ex.Message}");
-        }
-
-        return false;
     }
 
-    private static string? GetAudioFileExtension(OpenAudible audioFile)
+    private static void TryDelete(string path)
     {
-        if (!string.IsNullOrWhiteSpace(audioFile.M4B)) return ".m4b";
-        if (!string.IsNullOrWhiteSpace(audioFile.MP3)) return ".mp3";
-        return null;
-    }
-
-    private static string? ResolvePdfSourcePath(OpenAudible audioFile, string sourceRoot)
-    {
-        foreach (var candidate in GetPdfPathCandidates(audioFile, sourceRoot))
+        try
         {
-            if (File.Exists(candidate))
+            if (File.Exists(path))
             {
-                return candidate;
+                File.Delete(path);
             }
         }
-
-        return null;
-    }
-
-    private static IEnumerable<string> GetPdfPathCandidates(OpenAudible audioFile, string sourceRoot)
-    {
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var filePath in EnumerateFilePaths(audioFile.FilePaths))
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            if (!string.Equals(Path.GetExtension(filePath), ".pdf", StringComparison.OrdinalIgnoreCase))
-            {
-                continue;
-            }
-
-            foreach (var normalizedPath in ExpandSourcePathCandidates(filePath, sourceRoot))
-            {
-                if (seen.Add(normalizedPath))
-                {
-                    yield return normalizedPath;
-                }
-            }
-        }
-
-        foreach (var rawValue in new[] { audioFile.PDF, audioFile.Filename })
-        {
-            if (string.IsNullOrWhiteSpace(rawValue))
-            {
-                continue;
-            }
-
-            foreach (var candidate in ExpandPdfValueCandidates(rawValue.Trim(), sourceRoot))
-            {
-                if (seen.Add(candidate))
-                {
-                    yield return candidate;
-                }
-            }
+            // Best effort: a leftover .oabo-partial file is overwritten by the next run.
         }
     }
 
-    private static IEnumerable<string> EnumerateFilePaths(string? rawFilePaths)
-    {
-        if (string.IsNullOrWhiteSpace(rawFilePaths))
-        {
-            yield break;
-        }
-
-        foreach (var entry in rawFilePaths.Split(['|', ';', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            var candidate = entry.Trim().Trim('"');
-            if (!string.IsNullOrWhiteSpace(candidate))
-            {
-                yield return candidate;
-            }
-        }
-    }
-
-    private static IEnumerable<string> ExpandPdfValueCandidates(string value, string sourceRoot)
-    {
-        foreach (var candidate in ExpandSourcePathCandidates(value, sourceRoot))
-        {
-            yield return candidate;
-        }
-
-        if (!string.Equals(Path.GetExtension(value), ".pdf", StringComparison.OrdinalIgnoreCase))
-        {
-            foreach (var candidate in ExpandSourcePathCandidates($"{value}.pdf", sourceRoot))
-            {
-                yield return candidate;
-            }
-        }
-    }
-
-    private static IEnumerable<string> ExpandSourcePathCandidates(string value, string sourceRoot)
-    {
-        if (string.IsNullOrWhiteSpace(value))
-        {
-            yield break;
-        }
-
-        var trimmed = value.Trim().Trim('"');
-        if (string.IsNullOrWhiteSpace(trimmed))
-        {
-            yield break;
-        }
-
-        if (Path.IsPathRooted(trimmed))
-        {
-            yield return trimmed;
-            yield break;
-        }
-
-        yield return Path.Combine(sourceRoot, trimmed);
-
-        var fileName = Path.GetFileName(trimmed);
-        if (!string.Equals(fileName, trimmed, StringComparison.Ordinal))
-        {
-            yield return Path.Combine(sourceRoot, fileName);
-        }
-    }
-
-    private static string? SanitizeOptionalFileName(string? fileName)
-    {
-        if (string.IsNullOrWhiteSpace(fileName)) return null;
-        var invalidChars = Path.GetInvalidFileNameChars();
-        var sanitized = new string(fileName.Where(ch => !invalidChars.Contains(ch)).ToArray());
-        var trimmed = sanitized.TrimEnd('.', ' ').Trim();
-        if (string.IsNullOrWhiteSpace(trimmed)) return null;
-        return IsPlaceholderValue(trimmed) ? null : trimmed;
-    }
-
-    private static string SanitizeRequiredFileName(string? fileName)
-    {
-        return SanitizeOptionalFileName(fileName) ?? "Unknown";
-    }
-
-    private static string SanitizeAuthorName(string? value)
-    {
-        var sanitized = SanitizeOptionalFileName(value);
-        if (sanitized is null)
-        {
-            return "Unknown";
-        }
-
-        var authorSegments = new List<string>();
-        foreach (var rawSegment in sanitized.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-        {
-            var segment = rawSegment.Trim();
-            var namePart = segment;
-            string? descriptorPart = null;
-
-            var separatorIndex = segment.IndexOf(" - ", StringComparison.Ordinal);
-            if (separatorIndex >= 0)
-            {
-                namePart = segment[..separatorIndex].Trim();
-                descriptorPart = segment[(separatorIndex + 3)..].Trim();
-            }
-
-            if (!string.IsNullOrWhiteSpace(descriptorPart) && IsContributorDescriptor(descriptorPart))
-            {
-                if (authorSegments.Count > 0)
-                {
-                    break;
-                }
-
-                continue;
-            }
-
-            if (authorSegments.Count > 0 && IsKnownNonAuthorSegment(namePart))
-            {
-                continue;
-            }
-
-            if (!string.IsNullOrWhiteSpace(namePart))
-            {
-                authorSegments.Add(namePart);
-            }
-        }
-
-        if (authorSegments.Count == 0)
-        {
-            return "Unknown";
-        }
-
-        return string.Join(", ", authorSegments.Distinct(StringComparer.OrdinalIgnoreCase));
-    }
-
-    private static bool IsPlaceholderValue(string value)
-    {
-        return PlaceholderValues.Contains(value.Trim().ToLowerInvariant());
-    }
-
-    private static bool IsContributorDescriptor(string value)
-    {
-        var normalized = value.Trim().ToLowerInvariant();
-        return ContributorDescriptors.Any(normalized.Contains);
-    }
-
-    private static bool IsKnownNonAuthorSegment(string value)
-    {
-        var normalized = value.Trim().ToLowerInvariant();
-        return KnownNonAuthorSegments.Contains(normalized);
-    }
-
-    private static string? SanitizeSeriesSequence(string? value)
-    {
-        var sanitized = SanitizeOptionalFileName(value);
-        if (sanitized is null)
-        {
-            return null;
-        }
-
-        if (sanitized.StartsWith("Book ", StringComparison.OrdinalIgnoreCase))
-        {
-            sanitized = sanitized[5..].Trim();
-        }
-
-        var match = SequenceValueRegex.Match(sanitized);
-        if (!match.Success)
-        {
-            return null;
-        }
-
-        return match.Groups["value"].Value;
-    }
-
-    private static string ResolveSeriesDirectoryName(string authorDirectory, string requestedSeriesName)
-    {
-        var normalizedRequested = NormalizeSeriesKey(requestedSeriesName);
-        if (string.IsNullOrWhiteSpace(normalizedRequested))
-        {
-            return requestedSeriesName;
-        }
-
-        var existingSeriesDirectories = Directory.GetDirectories(authorDirectory);
-        foreach (var existingSeriesDirectory in existingSeriesDirectories)
-        {
-            var existingName = Path.GetFileName(existingSeriesDirectory);
-            if (string.IsNullOrWhiteSpace(existingName))
-            {
-                continue;
-            }
-
-            if (NormalizeSeriesKey(existingName) == normalizedRequested)
-            {
-                return existingName;
-            }
-        }
-
-        return requestedSeriesName;
-    }
-
-    private static string ResolveAuthorDirectoryName(string destinationRoot, string requestedAuthorName)
-    {
-        var normalizedRequested = NormalizeAuthorKey(requestedAuthorName);
-        if (string.IsNullOrWhiteSpace(normalizedRequested) || !Directory.Exists(destinationRoot))
-        {
-            return requestedAuthorName;
-        }
-
-        foreach (var existingAuthorDirectory in Directory.GetDirectories(destinationRoot))
-        {
-            var existingName = Path.GetFileName(existingAuthorDirectory);
-            if (string.IsNullOrWhiteSpace(existingName))
-            {
-                continue;
-            }
-
-            if (NormalizeAuthorKey(existingName) == normalizedRequested)
-            {
-                return existingName;
-            }
-        }
-
-        return requestedAuthorName;
-    }
-
-    private static string NormalizeAuthorKey(string value)
-    {
-        var normalized = value.Trim().ToLowerInvariant();
-        normalized = new string(normalized.Where(char.IsLetterOrDigit).ToArray());
-        return normalized;
-    }
-
-    private static string NormalizeSeriesKey(string value)
-    {
-        var normalized = value.Trim().ToLowerInvariant();
-
-        foreach (var article in LeadingArticles)
-        {
-            if (normalized.StartsWith(article))
-            {
-                normalized = normalized[article.Length..];
-                break;
-            }
-        }
-
-        foreach (var decorator in SeriesDecorators)
-        {
-            if (normalized.EndsWith(decorator))
-            {
-                normalized = normalized[..^decorator.Length];
-                break;
-            }
-        }
-
-        normalized = new string(normalized.Where(char.IsLetterOrDigit).ToArray());
-        return normalized;
-    }
-
+    /// <summary>
+    /// Cheap "is this the same file" check. Comparing every byte of a multi-gigabyte library on
+    /// every run is not viable, so size plus three sampled chunks is used instead.
+    /// </summary>
     private static async Task<bool> AreFilesSameAsync(string filePath1, string filePath2, CancellationToken cancellationToken)
     {
         try
@@ -519,33 +257,36 @@ public class FileSorter
             var fileInfo1 = new FileInfo(filePath1);
             var fileInfo2 = new FileInfo(filePath2);
 
-            // 🔹 Fastest check: Compare file size first
-            if (fileInfo1.Length != fileInfo2.Length) return false;
+            if (!fileInfo1.Exists || !fileInfo2.Exists || fileInfo1.Length != fileInfo2.Length)
+            {
+                return false;
+            }
 
-            const int chunkSize = 4096; // 4KB buffer for speed
+            var length = fileInfo1.Length;
+            if (length == 0)
+            {
+                return true;
+            }
+
+            const int chunkSize = 4096;
             var buffer1 = new byte[chunkSize];
             var buffer2 = new byte[chunkSize];
 
-            // 🔹 Open files in `FileShare.ReadWrite` mode to prevent locking issues
             await using var stream1 = new FileStream(filePath1, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, chunkSize, true);
             await using var stream2 = new FileStream(filePath2, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, chunkSize, true);
 
-            // 🔹 Compare first chunk
-            var bytesRead1 = await stream1.ReadAsync(buffer1.AsMemory(0, chunkSize), cancellationToken);
-            var bytesRead2 = await stream2.ReadAsync(buffer2.AsMemory(0, chunkSize), cancellationToken);
-            if (bytesRead1 != bytesRead2 || !buffer1.AsSpan(0, bytesRead1).SequenceEqual(buffer2.AsSpan(0, bytesRead2)))
-                return false;
-
-            // 🔹 Compare last chunk if file is larger than chunk size
-            if (fileInfo1.Length > chunkSize)
+            foreach (var offset in GetSampleOffsets(length, chunkSize))
             {
-                stream1.Seek(-chunkSize, SeekOrigin.End);
-                stream2.Seek(-chunkSize, SeekOrigin.End);
+                stream1.Seek(offset, SeekOrigin.Begin);
+                stream2.Seek(offset, SeekOrigin.Begin);
 
-                bytesRead1 = await stream1.ReadAsync(buffer1.AsMemory(0, chunkSize), cancellationToken);
-                bytesRead2 = await stream2.ReadAsync(buffer2.AsMemory(0, chunkSize), cancellationToken);
-                if (bytesRead1 != bytesRead2 || !buffer1.AsSpan(0, bytesRead1).SequenceEqual(buffer2.AsSpan(0, bytesRead2)))
+                var read1 = await stream1.ReadAtLeastAsync(buffer1, chunkSize, throwOnEndOfStream: false, cancellationToken);
+                var read2 = await stream2.ReadAtLeastAsync(buffer2, chunkSize, throwOnEndOfStream: false, cancellationToken);
+
+                if (read1 != read2 || !buffer1.AsSpan(0, read1).SequenceEqual(buffer2.AsSpan(0, read2)))
+                {
                     return false;
+                }
             }
 
             return true;
@@ -554,74 +295,110 @@ public class FileSorter
         {
             throw;
         }
-        catch
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
-            return false; // Assume files are different if any error occurs
+            return false; // Assume the files differ so the copy is retried.
         }
     }
 
+    private static IEnumerable<long> GetSampleOffsets(long length, int chunkSize)
+    {
+        yield return 0;
+
+        if (length <= chunkSize)
+        {
+            yield break;
+        }
+
+        var middle = Math.Max(0, (length / 2) - (chunkSize / 2));
+        if (middle > 0)
+        {
+            yield return middle;
+        }
+
+        yield return Math.Max(0, length - chunkSize);
+    }
+
+    internal static double CalculatePercentage(int current, int total)
+    {
+        if (total <= 0)
+        {
+            return 100;
+        }
+
+        return Math.Round(Math.Clamp((double)current / total, 0, 1) * 100, 2);
+    }
+
+    private static int GetMaxParallelism()
+    {
+        var configured = Environment.GetEnvironmentVariable("OABO_MAX_PARALLELISM");
+        if (int.TryParse(configured, out var requested) && requested > 0)
+        {
+            return requested;
+        }
+
+        // Copying is bound by the slowest of the two volumes, and on a network share or a spinning
+        // disk more concurrency makes throughput worse, not better.
+        return Math.Clamp(Environment.ProcessorCount / 4, 1, 8);
+    }
+
+    private static void RecordWarning(ConcurrentQueue<string> warnings, ref int warningCount, string message)
+    {
+        var count = Interlocked.Increment(ref warningCount);
+        if (count <= MaxReportedWarnings)
+        {
+            warnings.Enqueue(message);
+            WriteLine($"Warning: {message}");
+        }
+        else if (count == MaxReportedWarnings + 1)
+        {
+            WriteLine($"Warning: more than {MaxReportedWarnings} warnings, further warnings are suppressed.");
+        }
+    }
 
     private static void UpdateProgress(int currentProgress, int totalBooks, int copyBooks, string? title, ref int maxLineLength)
     {
-        var message = $"{Math.Round((decimal)currentProgress / totalBooks * 100, 2)}% ({currentProgress}/{totalBooks}) Transferred: {copyBooks} => {title}";
+        // When output is redirected (a service log, or the backend piped into the desktop app) the
+        // carriage-return trick just produces one enormous line, so log periodically instead.
+        if (Console.IsOutputRedirected)
+        {
+            if (currentProgress == totalBooks || currentProgress % 100 == 0)
+            {
+                WriteLine($"{CalculatePercentage(currentProgress, totalBooks):0.##}% ({currentProgress}/{totalBooks}) transferred: {copyBooks}");
+            }
+
+            return;
+        }
+
+        var message = $"{CalculatePercentage(currentProgress, totalBooks):0.##}% ({currentProgress}/{totalBooks}) Transferred: {copyBooks} => {title}";
 
         lock (ConsoleLock)
         {
-            // Clear previous message with spaces to prevent text corruption
-            Console.Write("\r" + new string(' ', maxLineLength) + "\r");
-            Console.Write(message);
-
-            // Track the longest message to properly clear on next update
-            maxLineLength = Math.Max(maxLineLength, message.Length);
+            try
+            {
+                Console.Write("\r" + new string(' ', maxLineLength) + "\r");
+                Console.Write(message);
+                maxLineLength = Math.Max(maxLineLength, message.Length);
+            }
+            catch (IOException)
+            {
+                // The console went away (the desktop app closed the pipe). Never fail a sort for it.
+            }
         }
     }
 
-    private static string BuildProgressLabel(OpenAudible audioFile)
+    private static void WriteLine(string message)
     {
-        var parts = new List<string>();
-
-        if (!string.IsNullOrWhiteSpace(audioFile.Author))
+        lock (ConsoleLock)
         {
-            parts.Add($"Artist: {audioFile.Author}");
+            try
+            {
+                Console.WriteLine(Console.IsOutputRedirected ? message : $"\n{message}");
+            }
+            catch (IOException)
+            {
+                // See UpdateProgress.
+            }
         }
-
-        if (!string.IsNullOrWhiteSpace(audioFile.SeriesName))
-        {
-            parts.Add($"Series: {audioFile.SeriesName}");
-        }
-
-        if (!string.IsNullOrWhiteSpace(audioFile.SeriesSequence))
-        {
-            parts.Add($"Book: {audioFile.SeriesSequence}");
-        }
-
-        if (!string.IsNullOrWhiteSpace(audioFile.Title))
-        {
-            parts.Add($"Title: {audioFile.Title}");
-        }
-
-        var fileName = audioFile.Filename;
-        if (!string.IsNullOrWhiteSpace(fileName))
-        {
-            parts.Add($"File: {fileName}");
-        }
-
-        return parts.Count > 0
-            ? string.Join(" | ", parts)
-            : audioFile.Title ?? "Unknown";
     }
-
-    private static async Task CopyFileAsync(string sourceFile, string destinationFile, CancellationToken cancellationToken)
-    {
-        const int bufferSize = 81920; // 80KB buffer for efficiency
-
-        await using var sourceStream = new FileStream(
-            sourceFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, bufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
-
-        await using var destinationStream = new FileStream(
-            destinationFile, FileMode.Create, FileAccess.Write, FileShare.None, bufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
-
-        await sourceStream.CopyToAsync(destinationStream, cancellationToken);
-    }
-
 }

--- a/AudioFileSorter/SortAudioFiles.cs
+++ b/AudioFileSorter/SortAudioFiles.cs
@@ -137,7 +137,16 @@ public class FileSorter
             }
 
             var currentProgress = Interlocked.Increment(ref progressCount);
+
+            // Read the sub-counts before the total they are part of. A worker increments
+            // copiedBooks and only then updatedBooks, so reading them the other way round can
+            // pair an old copied count with a newer updated count and publish a snapshot
+            // claiming more books were updated than were copied.
+            var currentUpdated = Volatile.Read(ref updatedBooks);
+            var currentSkipped = Volatile.Read(ref skippedBooks);
+            var currentFailed = Volatile.Read(ref failedBooks);
             var currentCopied = Volatile.Read(ref copiedBooks);
+
             UpdateProgress(currentProgress, totalBooks, currentCopied, item.Label, ref maxLineLength);
 
             progress?.Report(new SortProgressInfo
@@ -145,9 +154,9 @@ public class FileSorter
                 CurrentBook = currentProgress,
                 TotalBooks = totalBooks,
                 CopiedBooks = currentCopied,
-                UpdatedBooks = Volatile.Read(ref updatedBooks),
-                SkippedBooks = Volatile.Read(ref skippedBooks),
-                FailedBooks = Volatile.Read(ref failedBooks),
+                UpdatedBooks = currentUpdated,
+                SkippedBooks = currentSkipped,
+                FailedBooks = currentFailed,
                 CurrentTitle = item.Label,
                 Percentage = CalculatePercentage(currentProgress, totalBooks),
                 WarningCount = Volatile.Read(ref warningCount)
@@ -368,8 +377,12 @@ public class FileSorter
     /// Byte-for-byte comparison of two files. Used by <see cref="FileComparisonMode.Full"/>, where
     /// the point is to notice a re-released book that happens to be exactly the same size as the
     /// copy already on disk — something the sampled check cannot see.
+    ///
+    /// Internal rather than private so the "cancel stops it promptly" guarantee can be tested
+    /// directly: this is the only unbounded loop in a sort, and on a large library it is where a
+    /// cancelled run would otherwise keep grinding.
     /// </summary>
-    private static async Task<bool> AreFilesIdenticalAsync(string filePath1, string filePath2, CancellationToken cancellationToken)
+    internal static async Task<bool> AreFilesIdenticalAsync(string filePath1, string filePath2, CancellationToken cancellationToken)
     {
         byte[]? buffer1 = null;
         byte[]? buffer2 = null;
@@ -401,6 +414,11 @@ public class FileSorter
 
             while (true)
             {
+                // Checked here as well as passed to the reads: a whole-file comparison of a large
+                // book is many iterations long, and cancellation must not have to wait for the
+                // reads to notice it.
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var read1 = await stream1.ReadAtLeastAsync(
                     buffer1.AsMemory(0, ComparisonBufferSize), ComparisonBufferSize, throwOnEndOfStream: false, cancellationToken);
                 var read2 = await stream2.ReadAtLeastAsync(

--- a/AudioFileSorter/SortPlanner.cs
+++ b/AudioFileSorter/SortPlanner.cs
@@ -1,0 +1,280 @@
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter;
+
+/// <summary>
+/// Works out, up front and in list order, exactly which file is copied where.
+///
+/// Planning is deliberately single threaded and separate from copying. Deciding folder names
+/// while dozens of workers race to create them is how a library ends up with both
+/// "J.K. Rowling" and "JK Rowling", or with two books quietly overwriting each other; doing it
+/// once, in order, makes the outcome of a sort deterministic and repeatable.
+/// </summary>
+public sealed class SortPlanner
+{
+    private const int MaxDisambiguationAttempts = 100;
+
+    private readonly Dictionary<string, string> _resolvedDirectoryNames = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<string, string>> _directoryFileIndex = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, string> _claimedDestinations = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Builds the copy plan for every book in <paramref name="books"/>.</summary>
+    public List<PlannedCopy> Plan(IReadOnlyList<OpenAudible> books, string sourceRoot, string destinationRoot)
+    {
+        ArgumentNullException.ThrowIfNull(books);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceRoot);
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationRoot);
+
+        var fullDestinationRoot = Path.GetFullPath(destinationRoot);
+        var planned = new List<PlannedCopy>(books.Count);
+
+        foreach (var book in books)
+        {
+            planned.Add(PlanBook(book, sourceRoot, fullDestinationRoot));
+        }
+
+        return planned;
+    }
+
+    private PlannedCopy PlanBook(OpenAudible book, string sourceRoot, string destinationRoot)
+    {
+        var plan = BookNaming.BuildPlan(book);
+        var label = BuildLabel(book, plan);
+
+        var audioSource = SourceFileLocator.FindAudioFile(book, sourceRoot);
+        var pdfSource = SourceFileLocator.FindPdfFile(book, sourceRoot);
+
+        if (audioSource is null && pdfSource is null)
+        {
+            return new PlannedCopy
+            {
+                Book = book,
+                Label = label,
+                Warning = $"No source file found for \"{plan.FileStem}\" (file name: {book.Filename ?? "n/a"})"
+            };
+        }
+
+        // Folders are only named here, never created: a book whose files turn out to be
+        // unreadable should not leave an empty folder tree behind.
+        var targetDirectory = ResolveTargetDirectory(destinationRoot, plan);
+        if (!PathSanitizer.IsWithin(destinationRoot, targetDirectory))
+        {
+            return new PlannedCopy
+            {
+                Book = book,
+                Label = label,
+                Warning = $"Refusing to write \"{plan.FileStem}\" outside the destination folder"
+            };
+        }
+
+        string? audioDestination = null;
+        string? pdfDestination = null;
+        var warnings = new List<string>();
+
+        if (audioSource is not null)
+        {
+            audioDestination = ClaimDestination(
+                targetDirectory, plan.FileStem, Path.GetExtension(audioSource), audioSource, destinationRoot, warnings);
+        }
+
+        if (pdfSource is not null)
+        {
+            pdfDestination = ClaimDestination(
+                targetDirectory, plan.FileStem, ".pdf", pdfSource, destinationRoot, warnings);
+        }
+
+        return new PlannedCopy
+        {
+            Book = book,
+            Label = label,
+            TargetDirectory = audioDestination is null && pdfDestination is null ? null : targetDirectory,
+            AudioSource = audioDestination is null ? null : audioSource,
+            AudioDestination = audioDestination,
+            PdfSource = pdfDestination is null ? null : pdfSource,
+            PdfDestination = pdfDestination,
+            Warning = warnings.Count > 0 ? string.Join("; ", warnings) : null
+        };
+    }
+
+    private string ResolveTargetDirectory(string destinationRoot, BookSortPlan plan)
+    {
+        var authorDirectory = Path.Combine(
+            destinationRoot,
+            ResolveDirectoryName(destinationRoot, plan.Author, PathSanitizer.NormalizeComparisonKey));
+
+        if (plan.SeriesName is null)
+        {
+            return authorDirectory;
+        }
+
+        var seriesDirectory = Path.Combine(
+            authorDirectory,
+            ResolveDirectoryName(authorDirectory, plan.SeriesName, PathSanitizer.NormalizeSeriesKey));
+
+        return plan.SeriesSequence is null
+            ? seriesDirectory
+            : Path.Combine(seriesDirectory, $"Book {plan.SeriesSequence}");
+    }
+
+    /// <summary>
+    /// Picks the folder name to use inside <paramref name="parentDirectory"/>, preferring a folder
+    /// that already exists and means the same thing so repeat runs do not fragment a library.
+    /// </summary>
+    private string ResolveDirectoryName(string parentDirectory, string requestedName, Func<string?, string> normalizer)
+    {
+        var normalized = normalizer(requestedName);
+        if (normalized.Length == 0)
+        {
+            return requestedName;
+        }
+
+        var cacheKey = $"{parentDirectory}\u0000{normalized}";
+        if (_resolvedDirectoryNames.TryGetValue(cacheKey, out var cached))
+        {
+            return cached;
+        }
+
+        var resolved = requestedName;
+        foreach (var existingDirectory in SafeEnumerateDirectories(parentDirectory))
+        {
+            var existingName = Path.GetFileName(existingDirectory);
+            if (!string.IsNullOrWhiteSpace(existingName) && normalizer(existingName) == normalized)
+            {
+                resolved = existingName;
+                break;
+            }
+        }
+
+        _resolvedDirectoryNames[cacheKey] = resolved;
+        return resolved;
+    }
+
+    /// <summary>
+    /// Reserves a destination path for one source file, reusing an equivalent file that is already
+    /// there and disambiguating when two different books would land on the same name.
+    /// </summary>
+    private string? ClaimDestination(
+        string directory,
+        string stem,
+        string extension,
+        string sourcePath,
+        string destinationRoot,
+        List<string> warnings)
+    {
+        extension = string.IsNullOrWhiteSpace(extension) ? string.Empty : extension;
+
+        var fileIndex = GetDirectoryFileIndex(directory);
+        var indexKey = BuildFileIndexKey(stem, extension);
+
+        var fileName = fileIndex.TryGetValue(indexKey, out var existingName)
+            ? existingName
+            : $"{stem}{extension}";
+
+        for (var attempt = 1; attempt <= MaxDisambiguationAttempts; attempt++)
+        {
+            var candidateName = attempt == 1 ? fileName : $"{stem} ({attempt}){extension}";
+            var candidatePath = Path.Combine(directory, candidateName);
+
+            if (!PathSanitizer.IsWithin(destinationRoot, candidatePath))
+            {
+                warnings.Add($"Refusing to write \"{candidateName}\" outside the destination folder");
+                return null;
+            }
+
+            if (!_claimedDestinations.TryGetValue(candidatePath, out var claimedBy))
+            {
+                _claimedDestinations[candidatePath] = sourcePath;
+                fileIndex.TryAdd(BuildFileIndexKey(Path.GetFileNameWithoutExtension(candidateName), extension), candidateName);
+                return candidatePath;
+            }
+
+            if (string.Equals(claimedBy, sourcePath, StringComparison.OrdinalIgnoreCase))
+            {
+                // The same physical file listed twice in the export: copy it once.
+                return null;
+            }
+        }
+
+        warnings.Add($"Could not find a free file name for \"{stem}{extension}\"");
+        return null;
+    }
+
+    private Dictionary<string, string> GetDirectoryFileIndex(string directory)
+    {
+        if (_directoryFileIndex.TryGetValue(directory, out var index))
+        {
+            return index;
+        }
+
+        index = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var file in SafeEnumerateFiles(directory))
+        {
+            var name = Path.GetFileName(file);
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            index.TryAdd(
+                BuildFileIndexKey(Path.GetFileNameWithoutExtension(name), Path.GetExtension(name)),
+                name);
+        }
+
+        _directoryFileIndex[directory] = index;
+        return index;
+    }
+
+    private static string BuildFileIndexKey(string stem, string extension)
+    {
+        return $"{PathSanitizer.NormalizeComparisonKey(stem)}\u0000{extension.ToLowerInvariant()}";
+    }
+
+    private static IEnumerable<string> SafeEnumerateDirectories(string path)
+    {
+        try
+        {
+            return Directory.Exists(path) ? Directory.EnumerateDirectories(path).ToArray() : [];
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    private static IEnumerable<string> SafeEnumerateFiles(string path)
+    {
+        try
+        {
+            return Directory.Exists(path) ? Directory.EnumerateFiles(path).ToArray() : [];
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return [];
+        }
+    }
+
+    private static string BuildLabel(OpenAudible book, BookSortPlan plan)
+    {
+        var parts = new List<string> { $"Artist: {plan.Author}" };
+
+        if (plan.SeriesName is not null)
+        {
+            parts.Add($"Series: {plan.SeriesName}");
+        }
+
+        if (plan.SeriesSequence is not null)
+        {
+            parts.Add($"Book: {plan.SeriesSequence}");
+        }
+
+        var title = PathSanitizer.SanitizeSegment(book.Title) ?? plan.FileStem;
+        parts.Add($"Title: {title}");
+
+        if (!string.IsNullOrWhiteSpace(book.Filename))
+        {
+            parts.Add($"File: {book.Filename.Trim()}");
+        }
+
+        return string.Join(" | ", parts);
+    }
+}

--- a/AudioFileSorter/SourceFileLocator.cs
+++ b/AudioFileSorter/SourceFileLocator.cs
@@ -186,15 +186,18 @@ public static class SourceFileLocator
         if (Path.IsPathRooted(trimmed))
         {
             yield return trimmed;
-            yield break;
+        }
+        else
+        {
+            yield return Path.Combine(sourceRoot, trimmed);
         }
 
-        yield return Path.Combine(sourceRoot, trimmed);
-
-        // A path recorded on Windows ("Books\\Title.m4b") is a single file name on Linux, so also
-        // try the bare file name against the source root.
+        // The recorded path is where the file was when the export was written, which is very
+        // often not where it is now: a different machine, a different drive letter, or a path
+        // written on Windows and read on Linux. Fall back to the bare file name inside the
+        // source folder the user actually chose.
         var fileName = GetPortableFileName(trimmed);
-        if (!string.Equals(fileName, trimmed, StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(fileName))
+        if (!string.IsNullOrWhiteSpace(fileName) && !string.Equals(fileName, trimmed, StringComparison.Ordinal))
         {
             yield return Path.Combine(sourceRoot, fileName);
         }

--- a/AudioFileSorter/SourceFileLocator.cs
+++ b/AudioFileSorter/SourceFileLocator.cs
@@ -1,0 +1,227 @@
+using AudioFileSorter.Model;
+
+namespace AudioFileSorter;
+
+/// <summary>
+/// Finds the files belonging to a book inside the source folder. OpenAudible exports describe the
+/// same file in several ways depending on version and platform, so every plausible spelling is
+/// tried before a book is reported as missing.
+/// </summary>
+public static class SourceFileLocator
+{
+    private static readonly string[] AudioExtensions = [".m4b", ".mp3", ".m4a"];
+
+    /// <summary>Locates the audio file for a book, or null when none of the candidates exist.</summary>
+    public static string? FindAudioFile(OpenAudible book, string sourceRoot)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        foreach (var candidate in GetAudioCandidates(book, sourceRoot))
+        {
+            if (FileExists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>Locates the companion PDF for a book, or null when there is none.</summary>
+    public static string? FindPdfFile(OpenAudible book, string sourceRoot)
+    {
+        ArgumentNullException.ThrowIfNull(book);
+
+        foreach (var candidate in GetPdfCandidates(book, sourceRoot))
+        {
+            if (FileExists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<string> GetAudioCandidates(OpenAudible book, string sourceRoot)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // The M4B/MP3 columns say which format was downloaded, so honour them first to keep the
+        // extension of an already-organised library stable.
+        foreach (var (marker, extension) in new[] { (book.M4B, ".m4b"), (book.MP3, ".mp3") })
+        {
+            if (string.IsNullOrWhiteSpace(marker) || string.IsNullOrWhiteSpace(book.Filename))
+            {
+                continue;
+            }
+
+            foreach (var candidate in ExpandSourceCandidates($"{book.Filename.Trim()}{extension}", sourceRoot))
+            {
+                if (seen.Add(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+
+        foreach (var filePath in EnumerateFilePaths(book.FilePaths))
+        {
+            if (!IsAudioExtension(Path.GetExtension(filePath)))
+            {
+                continue;
+            }
+
+            foreach (var candidate in ExpandSourceCandidates(filePath, sourceRoot))
+            {
+                if (seen.Add(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+
+        // Last resort: probe the source folder directly. Exports produced by older OpenAudible
+        // versions leave the format columns empty even though the file is right there.
+        if (!string.IsNullOrWhiteSpace(book.Filename))
+        {
+            foreach (var extension in AudioExtensions)
+            {
+                foreach (var candidate in ExpandSourceCandidates($"{book.Filename.Trim()}{extension}", sourceRoot))
+                {
+                    if (seen.Add(candidate))
+                    {
+                        yield return candidate;
+                    }
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetPdfCandidates(OpenAudible book, string sourceRoot)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var filePath in EnumerateFilePaths(book.FilePaths))
+        {
+            if (!string.Equals(Path.GetExtension(filePath), ".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (var candidate in ExpandSourceCandidates(filePath, sourceRoot))
+            {
+                if (seen.Add(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+
+        foreach (var rawValue in new[] { book.PDF, book.Filename })
+        {
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                continue;
+            }
+
+            var value = rawValue.Trim();
+            foreach (var candidate in ExpandSourceCandidates(value, sourceRoot))
+            {
+                if (seen.Add(candidate) && string.Equals(Path.GetExtension(candidate), ".pdf", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return candidate;
+                }
+            }
+
+            if (string.Equals(Path.GetExtension(value), ".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach (var candidate in ExpandSourceCandidates($"{value}.pdf", sourceRoot))
+            {
+                if (seen.Add(candidate))
+                {
+                    yield return candidate;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> EnumerateFilePaths(string? rawFilePaths)
+    {
+        if (string.IsNullOrWhiteSpace(rawFilePaths))
+        {
+            yield break;
+        }
+
+        var entries = rawFilePaths.Split(
+            ['|', ';', '\r', '\n'],
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        foreach (var entry in entries)
+        {
+            var candidate = entry.Trim().Trim('"');
+            if (!string.IsNullOrWhiteSpace(candidate))
+            {
+                yield return candidate;
+            }
+        }
+    }
+
+    private static IEnumerable<string> ExpandSourceCandidates(string value, string sourceRoot)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            yield break;
+        }
+
+        var trimmed = value.Trim().Trim('"');
+        if (string.IsNullOrWhiteSpace(trimmed))
+        {
+            yield break;
+        }
+
+        if (Path.IsPathRooted(trimmed))
+        {
+            yield return trimmed;
+            yield break;
+        }
+
+        yield return Path.Combine(sourceRoot, trimmed);
+
+        // A path recorded on Windows ("Books\\Title.m4b") is a single file name on Linux, so also
+        // try the bare file name against the source root.
+        var fileName = GetPortableFileName(trimmed);
+        if (!string.Equals(fileName, trimmed, StringComparison.Ordinal) && !string.IsNullOrWhiteSpace(fileName))
+        {
+            yield return Path.Combine(sourceRoot, fileName);
+        }
+    }
+
+    private static string GetPortableFileName(string value)
+    {
+        var separatorIndex = value.LastIndexOfAny(['/', '\\']);
+        return separatorIndex >= 0 ? value[(separatorIndex + 1)..] : value;
+    }
+
+    private static bool IsAudioExtension(string? extension)
+    {
+        return !string.IsNullOrEmpty(extension) &&
+               AudioExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static bool FileExists(string path)
+    {
+        try
+        {
+            return File.Exists(path);
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or IOException or UnauthorizedAccessException)
+        {
+            // A malformed candidate is simply not a match; it must never abort the whole sort.
+            return false;
+        }
+    }
+}

--- a/ManagerApi/ManagerApi.csproj
+++ b/ManagerApi/ManagerApi.csproj
@@ -10,4 +10,8 @@
         <ProjectReference Include="..\AudioFileSorter\AudioFileSorter.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="AudioFileSorter.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/ManagerApi/Program.cs
+++ b/ManagerApi/Program.cs
@@ -1,3 +1,4 @@
+using AudioFileSorter.Model;
 using ManagerApi.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -5,6 +6,16 @@ var builder = WebApplication.CreateBuilder(args);
 var csvPath = Environment.GetEnvironmentVariable("CSV_PATH") ?? string.Empty;
 var sourcePath = Environment.GetEnvironmentVariable("SOURCE_PATH") ?? string.Empty;
 var destinationPath = Environment.GetEnvironmentVariable("DESTINATION_PATH") ?? string.Empty;
+
+// COMPARISON_MODE is the server-wide default: a container can be set up to verify contents on
+// every run, and a request that names a mode explicitly still wins.
+var configuredComparisonMode = Environment.GetEnvironmentVariable("COMPARISON_MODE");
+if (!SortOptions.TryParseComparisonMode(configuredComparisonMode, out var defaultComparisonMode))
+{
+    Console.Error.WriteLine(
+        $"Ignoring COMPARISON_MODE=\"{configuredComparisonMode}\": expected \"quick\" or \"full\". Using \"quick\".");
+    defaultComparisonMode = SortOptions.Default.ComparisonMode;
+}
 
 builder.Services.AddCors(options =>
 {
@@ -36,6 +47,7 @@ app.MapGet("/api/config", () => Results.Ok(new
     sourcePath,
     destinationPath,
     webMode = true,
+    comparisonMode = SortOptions.ToWireValue(defaultComparisonMode),
     csvExists = !string.IsNullOrWhiteSpace(csvPath) && File.Exists(csvPath),
     sourceExists = !string.IsNullOrWhiteSpace(sourcePath) && Directory.Exists(sourcePath),
     destinationExists = !string.IsNullOrWhiteSpace(destinationPath) && Directory.Exists(destinationPath)
@@ -92,6 +104,18 @@ app.MapPost("/api/sort/start", (SortRequest? request, SortService sortService) =
         return Results.BadRequest(new { error = "All paths are required" });
     }
 
+    // An omitted mode means "whatever this server is configured for", so a container started with
+    // COMPARISON_MODE=full verifies contents even for callers that never heard of the setting.
+    var comparisonMode = defaultComparisonMode;
+    if (!string.IsNullOrWhiteSpace(request.ComparisonMode) &&
+        !SortOptions.TryParseComparisonMode(request.ComparisonMode, out comparisonMode))
+    {
+        return Results.BadRequest(new
+        {
+            error = $"Unknown comparison mode \"{request.ComparisonMode}\". Use \"quick\" or \"full\"."
+        });
+    }
+
     // Validate before starting so the user gets a real error instead of a run that reports
     // failure seconds later, or worse, never reports at all.
     if (!File.Exists(request.CsvPath))
@@ -122,7 +146,8 @@ app.MapPost("/api/sort/start", (SortRequest? request, SortService sortService) =
     }
 
     // Checking IsSorting separately would leave a window where two requests both start a run.
-    if (!sortService.TryStartSort(request.CsvPath, request.SourcePath, request.DestinationPath, out var sortTask))
+    var options = new SortOptions { ComparisonMode = comparisonMode };
+    if (!sortService.TryStartSort(request.CsvPath, request.SourcePath, request.DestinationPath, options, out var sortTask))
     {
         return Results.Conflict(new { error = "Sort already in progress" });
     }
@@ -131,7 +156,11 @@ app.MapPost("/api/sort/start", (SortRequest? request, SortService sortService) =
         t => logger.LogError(t.Exception, "Sort task faulted"),
         TaskContinuationOptions.OnlyOnFaulted);
 
-    return Results.Ok(new { message = "Sort started" });
+    return Results.Ok(new
+    {
+        message = "Sort started",
+        comparisonMode = SortOptions.ToWireValue(comparisonMode)
+    });
 });
 
 app.MapGet("/api/sort/progress", (SortService sortService) => Results.Ok(sortService.GetProgress()));
@@ -167,7 +196,9 @@ static bool PathsOverlap(string sourcePath, string destinationPath)
 }
 
 record ParseRequest(string CsvPath);
-record SortRequest(string CsvPath, string SourcePath, string DestinationPath);
+
+/// <param name="ComparisonMode">"quick" or "full". Omitted means the server default.</param>
+record SortRequest(string CsvPath, string SourcePath, string DestinationPath, string? ComparisonMode = null);
 
 /// <summary>Exposed so the integration tests can drive the real application host.</summary>
 public partial class Program;

--- a/ManagerApi/Program.cs
+++ b/ManagerApi/Program.cs
@@ -1,5 +1,3 @@
-using AudioFileSorter;
-using AudioFileSorter.Model;
 using ManagerApi.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -24,6 +22,8 @@ builder.WebHost.UseUrls(Environment.GetEnvironmentVariable("ASPNETCORE_URLS") ??
 
 var app = builder.Build();
 
+var logger = app.Logger;
+
 app.UseCors();
 app.UseDefaultFiles();
 app.UseStaticFiles();
@@ -35,67 +35,139 @@ app.MapGet("/api/config", () => Results.Ok(new
     csvPath,
     sourcePath,
     destinationPath,
-    webMode = true
+    webMode = true,
+    csvExists = !string.IsNullOrWhiteSpace(csvPath) && File.Exists(csvPath),
+    sourceExists = !string.IsNullOrWhiteSpace(sourcePath) && Directory.Exists(sourcePath),
+    destinationExists = !string.IsNullOrWhiteSpace(destinationPath) && Directory.Exists(destinationPath)
 }));
 
-app.MapPost("/api/books/parse", async (ParseRequest request, SortService sortService) =>
+app.MapPost("/api/books/parse", async (ParseRequest? request, SortService sortService, CancellationToken cancellationToken) =>
 {
-    if (string.IsNullOrWhiteSpace(request.CsvPath))
+    if (request is null || string.IsNullOrWhiteSpace(request.CsvPath))
+    {
         return Results.BadRequest(new { error = "CSV path is required" });
-
-    if (!File.Exists(request.CsvPath))
-        return Results.BadRequest(new { error = "CSV file not found" });
+    }
 
     try
     {
-        var books = await sortService.ParseBooks(request.CsvPath);
-        return Results.Ok(books);
+        var result = await sortService.ParseBooks(request.CsvPath, cancellationToken);
+
+        foreach (var warning in result.Warnings)
+        {
+            logger.LogWarning("CSV import: {Warning}", warning);
+        }
+
+        return Results.Ok(new
+        {
+            books = result.Books,
+            skippedRows = result.SkippedRows,
+            warnings = result.Warnings
+        });
+    }
+    catch (Exception ex) when (ex is FileNotFoundException or ArgumentException or InvalidDataException or InvalidOperationException)
+    {
+        logger.LogWarning(ex, "Failed to parse {CsvPath}", request.CsvPath);
+        return Results.BadRequest(new { error = ex.Message });
+    }
+    catch (OperationCanceledException)
+    {
+        return Results.StatusCode(StatusCodes.Status499ClientClosedRequest);
     }
     catch (Exception ex)
     {
-        return Results.BadRequest(new { error = ex.Message });
+        logger.LogError(ex, "Unexpected error parsing {CsvPath}", request.CsvPath);
+        return Results.BadRequest(new { error = $"Could not read the CSV file: {ex.Message}" });
     }
 });
 
-app.MapGet("/api/books", (SortService sortService) =>
-{
-    return Results.Ok(sortService.GetBooks());
-});
+app.MapGet("/api/books", (SortService sortService) => Results.Ok(sortService.GetBooks()));
 
-app.MapPost("/api/sort/start", (SortRequest request, SortService sortService) =>
+app.MapPost("/api/sort/start", (SortRequest? request, SortService sortService) =>
 {
-    if (string.IsNullOrWhiteSpace(request.CsvPath) ||
+    if (request is null ||
+        string.IsNullOrWhiteSpace(request.CsvPath) ||
         string.IsNullOrWhiteSpace(request.SourcePath) ||
         string.IsNullOrWhiteSpace(request.DestinationPath))
+    {
         return Results.BadRequest(new { error = "All paths are required" });
+    }
 
-    if (sortService.IsSorting)
+    // Validate before starting so the user gets a real error instead of a run that reports
+    // failure seconds later, or worse, never reports at all.
+    if (!File.Exists(request.CsvPath))
+    {
+        return Results.BadRequest(new { error = $"CSV file not found: {request.CsvPath}" });
+    }
+
+    if (!Directory.Exists(request.SourcePath))
+    {
+        return Results.BadRequest(new { error = $"Source folder not found: {request.SourcePath}" });
+    }
+
+    try
+    {
+        Directory.CreateDirectory(request.DestinationPath);
+    }
+    catch (Exception ex)
+    {
+        return Results.BadRequest(new { error = $"Destination folder is not writable: {ex.Message}" });
+    }
+
+    if (PathsOverlap(request.SourcePath, request.DestinationPath))
+    {
+        return Results.BadRequest(new
+        {
+            error = "The destination folder cannot be the source folder or live inside it."
+        });
+    }
+
+    // Checking IsSorting separately would leave a window where two requests both start a run.
+    if (!sortService.TryStartSort(request.CsvPath, request.SourcePath, request.DestinationPath, out var sortTask))
+    {
         return Results.Conflict(new { error = "Sort already in progress" });
+    }
 
-    _ = Task.Run(() => sortService.StartSort(request.CsvPath, request.SourcePath, request.DestinationPath));
+    _ = sortTask.ContinueWith(
+        t => logger.LogError(t.Exception, "Sort task faulted"),
+        TaskContinuationOptions.OnlyOnFaulted);
+
     return Results.Ok(new { message = "Sort started" });
 });
 
-app.MapGet("/api/sort/progress", (SortService sortService) =>
-{
-    return Results.Ok(sortService.GetProgress());
-});
+app.MapGet("/api/sort/progress", (SortService sortService) => Results.Ok(sortService.GetProgress()));
 
 app.MapPost("/api/sort/cancel", (SortService sortService) =>
 {
-    if (!sortService.IsSorting)
-        return Results.BadRequest(new { error = "No sort is currently running" });
-
-    var canceled = sortService.CancelSort();
-    if (!canceled)
-        return Results.BadRequest(new { error = "No sort is currently running" });
-
-    return Results.Ok(new { message = "Sort cancellation requested" });
+    return sortService.CancelSort()
+        ? Results.Ok(new { message = "Sort cancellation requested" })
+        : Results.BadRequest(new { error = "No sort is currently running" });
 });
 
 app.MapFallbackToFile("index.html");
 
 app.Run();
 
+// Copying a library into itself (or into a subfolder of itself) makes the source grow while it is
+// being read, which never terminates cleanly.
+static bool PathsOverlap(string sourcePath, string destinationPath)
+{
+    try
+    {
+        var source = Path.TrimEndingDirectorySeparator(Path.GetFullPath(sourcePath));
+        var destination = Path.TrimEndingDirectorySeparator(Path.GetFullPath(destinationPath));
+        var comparison = OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
+
+        return string.Equals(source, destination, comparison) ||
+               destination.StartsWith(source + Path.DirectorySeparatorChar, comparison);
+    }
+    catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+    {
+        return false;
+    }
+}
+
 record ParseRequest(string CsvPath);
 record SortRequest(string CsvPath, string SourcePath, string DestinationPath);
+
+/// <summary>Exposed so the integration tests can drive the real application host.</summary>
+public partial class Program;

--- a/ManagerApi/Services/SortService.cs
+++ b/ManagerApi/Services/SortService.cs
@@ -97,11 +97,17 @@ public class SortService
         }
     }
 
+    /// <summary>Starts a sort with the default settings.</summary>
+    public bool TryStartSort(string csvPath, string sourcePath, string destinationPath, out Task sortTask)
+    {
+        return TryStartSort(csvPath, sourcePath, destinationPath, null, out sortTask);
+    }
+
     /// <summary>
     /// Starts a sort if none is running. Returns false when one already is, so the caller can tell
     /// the user the truth instead of reporting a run that never started.
     /// </summary>
-    public bool TryStartSort(string csvPath, string sourcePath, string destinationPath, out Task sortTask)
+    public bool TryStartSort(string csvPath, string sourcePath, string destinationPath, SortOptions? options, out Task sortTask)
     {
         lock (_sortLock)
         {
@@ -116,19 +122,19 @@ public class SortService
             _sortCancellation = new CancellationTokenSource();
         }
 
-        sortTask = RunSort(csvPath, sourcePath, destinationPath);
+        sortTask = RunSort(csvPath, sourcePath, destinationPath, options ?? SortOptions.Default);
         return true;
     }
 
     /// <summary>Starts a sort and waits for it to finish. Used by tests and by direct callers.</summary>
-    public Task StartSort(string csvPath, string sourcePath, string destinationPath)
+    public Task StartSort(string csvPath, string sourcePath, string destinationPath, SortOptions? options = null)
     {
-        return TryStartSort(csvPath, sourcePath, destinationPath, out var sortTask)
+        return TryStartSort(csvPath, sourcePath, destinationPath, options, out var sortTask)
             ? sortTask
             : Task.CompletedTask;
     }
 
-    private async Task RunSort(string csvPath, string sourcePath, string destinationPath)
+    private async Task RunSort(string csvPath, string sourcePath, string destinationPath, SortOptions options)
     {
         CancellationTokenSource cancellation;
         lock (_sortLock)
@@ -144,13 +150,14 @@ public class SortService
             // per-book report could be delivered after the final one and leave the run looking
             // unfinished forever.
             var progress = new InlineProgress<SortProgressInfo>(SetProgress);
-            var summary = await _fileSorter.SortAudioFiles(sourcePath, destinationPath, books, progress, cancellation.Token);
+            var summary = await _fileSorter.SortAudioFiles(sourcePath, destinationPath, books, options, progress, cancellation.Token);
 
             SetProgress(new SortProgressInfo
             {
                 CurrentBook = summary.TotalBooks,
                 TotalBooks = summary.TotalBooks,
                 CopiedBooks = summary.CopiedBooks,
+                UpdatedBooks = summary.UpdatedBooks,
                 SkippedBooks = summary.SkippedBooks,
                 FailedBooks = summary.FailedBooks,
                 WarningCount = summary.WarningCount,
@@ -166,6 +173,7 @@ public class SortService
                 CurrentBook = snapshot.CurrentBook,
                 TotalBooks = snapshot.TotalBooks,
                 CopiedBooks = snapshot.CopiedBooks,
+                UpdatedBooks = snapshot.UpdatedBooks,
                 SkippedBooks = snapshot.SkippedBooks,
                 FailedBooks = snapshot.FailedBooks,
                 WarningCount = snapshot.WarningCount,
@@ -183,6 +191,7 @@ public class SortService
                 CurrentBook = snapshot.CurrentBook,
                 TotalBooks = snapshot.TotalBooks,
                 CopiedBooks = snapshot.CopiedBooks,
+                UpdatedBooks = snapshot.UpdatedBooks,
                 SkippedBooks = snapshot.SkippedBooks,
                 FailedBooks = snapshot.FailedBooks,
                 WarningCount = snapshot.WarningCount,

--- a/ManagerApi/Services/SortService.cs
+++ b/ManagerApi/Services/SortService.cs
@@ -3,27 +3,77 @@ using AudioFileSorter.Model;
 
 namespace ManagerApi.Services;
 
+/// <summary>
+/// Owns the single sort run the backend allows at a time, plus the library it works from.
+/// </summary>
 public class SortService
 {
     private readonly CsvParser _csvParser = new();
     private readonly FileSorter _fileSorter = new();
     private readonly object _sortLock = new();
-    private List<OpenAudible> _books = new();
+
+    private List<OpenAudible> _books = [];
+    private string? _booksCsvPath;
     private SortProgressInfo _currentProgress = new();
     private CancellationTokenSource? _sortCancellation;
-    private volatile bool _isSorting;
+    private bool _isSorting;
 
-    public bool IsSorting => _isSorting;
-
-    public async Task<List<OpenAudible>> ParseBooks(string csvPath)
+    public bool IsSorting
     {
-        _books = await _csvParser.ParseDataCsv(csvPath, CancellationToken.None);
-        return _books;
+        get
+        {
+            lock (_sortLock)
+            {
+                return _isSorting;
+            }
+        }
     }
 
-    public List<OpenAudible> GetBooks() => _books;
+    /// <summary>Reads a book list into memory, replacing whatever was loaded before.</summary>
+    /// <exception cref="InvalidOperationException">A sort is currently running.</exception>
+    public async Task<CsvParseResult> ParseBooks(string csvPath, CancellationToken cancellationToken = default)
+    {
+        lock (_sortLock)
+        {
+            if (_isSorting)
+            {
+                throw new InvalidOperationException("A sort is currently running. Cancel it before loading a different library.");
+            }
+        }
 
-    public SortProgressInfo GetProgress() => _currentProgress;
+        var result = await _csvParser.ParseAsync(csvPath, cancellationToken);
+
+        lock (_sortLock)
+        {
+            // Re-check: a sort may have started while the file was being read. Losing the parse
+            // result is better than swapping the list out from under a running sort.
+            if (_isSorting)
+            {
+                throw new InvalidOperationException("A sort started while the library was loading. Try again once it finishes.");
+            }
+
+            _books = result.Books;
+            _booksCsvPath = Path.GetFullPath(csvPath);
+        }
+
+        return result;
+    }
+
+    public List<OpenAudible> GetBooks()
+    {
+        lock (_sortLock)
+        {
+            return _books;
+        }
+    }
+
+    public SortProgressInfo GetProgress()
+    {
+        lock (_sortLock)
+        {
+            return _currentProgress;
+        }
+    }
 
     public bool CancelSort()
     {
@@ -34,73 +84,112 @@ public class SortService
                 return false;
             }
 
-            _sortCancellation.Cancel();
+            try
+            {
+                _sortCancellation.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+
             return true;
         }
     }
 
-    public async Task StartSort(string csvPath, string sourcePath, string destinationPath)
+    /// <summary>
+    /// Starts a sort if none is running. Returns false when one already is, so the caller can tell
+    /// the user the truth instead of reporting a run that never started.
+    /// </summary>
+    public bool TryStartSort(string csvPath, string sourcePath, string destinationPath, out Task sortTask)
     {
-        CancellationTokenSource cancellation;
-
         lock (_sortLock)
         {
-            if (_isSorting) return;
+            if (_isSorting)
+            {
+                sortTask = Task.CompletedTask;
+                return false;
+            }
 
             _isSorting = true;
             _currentProgress = new SortProgressInfo();
             _sortCancellation = new CancellationTokenSource();
-            cancellation = _sortCancellation;
+        }
+
+        sortTask = RunSort(csvPath, sourcePath, destinationPath);
+        return true;
+    }
+
+    /// <summary>Starts a sort and waits for it to finish. Used by tests and by direct callers.</summary>
+    public Task StartSort(string csvPath, string sourcePath, string destinationPath)
+    {
+        return TryStartSort(csvPath, sourcePath, destinationPath, out var sortTask)
+            ? sortTask
+            : Task.CompletedTask;
+    }
+
+    private async Task RunSort(string csvPath, string sourcePath, string destinationPath)
+    {
+        CancellationTokenSource cancellation;
+        lock (_sortLock)
+        {
+            cancellation = _sortCancellation!;
         }
 
         try
         {
-            if (_books.Count == 0)
-            {
-                _books = await _csvParser.ParseDataCsv(csvPath, CancellationToken.None);
-            }
+            var books = await EnsureBooksLoaded(csvPath, cancellation.Token);
 
-            var progress = new Progress<SortProgressInfo>(p =>
-            {
-                _currentProgress = p;
-            });
+            var progress = new Progress<SortProgressInfo>(SetProgress);
+            var summary = await _fileSorter.SortAudioFiles(sourcePath, destinationPath, books, progress, cancellation.Token);
 
-            await _fileSorter.SortAudioFiles(sourcePath, destinationPath, _books, progress, cancellation.Token);
-
-            _currentProgress = new SortProgressInfo
+            SetProgress(new SortProgressInfo
             {
-                CurrentBook = _books.Count,
-                TotalBooks = _books.Count,
-                CopiedBooks = _currentProgress.CopiedBooks,
+                CurrentBook = summary.TotalBooks,
+                TotalBooks = summary.TotalBooks,
+                CopiedBooks = summary.CopiedBooks,
+                SkippedBooks = summary.SkippedBooks,
+                FailedBooks = summary.FailedBooks,
+                WarningCount = summary.WarningCount,
                 Percentage = 100,
                 IsComplete = true
-            };
+            });
         }
         catch (OperationCanceledException)
         {
-            _currentProgress = new SortProgressInfo
+            var snapshot = GetProgress();
+            SetProgress(new SortProgressInfo
             {
-                CurrentBook = _currentProgress.CurrentBook,
-                TotalBooks = _currentProgress.TotalBooks,
-                CopiedBooks = _currentProgress.CopiedBooks,
-                CurrentTitle = _currentProgress.CurrentTitle,
-                Percentage = _currentProgress.Percentage,
+                CurrentBook = snapshot.CurrentBook,
+                TotalBooks = snapshot.TotalBooks,
+                CopiedBooks = snapshot.CopiedBooks,
+                SkippedBooks = snapshot.SkippedBooks,
+                FailedBooks = snapshot.FailedBooks,
+                WarningCount = snapshot.WarningCount,
+                CurrentTitle = snapshot.CurrentTitle,
+                Percentage = snapshot.Percentage,
                 IsComplete = true,
                 IsCanceled = true
-            };
+            });
         }
         catch (Exception ex)
         {
-            _currentProgress = new SortProgressInfo
+            var snapshot = GetProgress();
+            SetProgress(new SortProgressInfo
             {
-                CurrentBook = _currentProgress.CurrentBook,
-                TotalBooks = _currentProgress.TotalBooks,
-                CopiedBooks = _currentProgress.CopiedBooks,
-                CurrentTitle = _currentProgress.CurrentTitle,
-                Percentage = _currentProgress.Percentage,
+                CurrentBook = snapshot.CurrentBook,
+                TotalBooks = snapshot.TotalBooks,
+                CopiedBooks = snapshot.CopiedBooks,
+                SkippedBooks = snapshot.SkippedBooks,
+                FailedBooks = snapshot.FailedBooks,
+                WarningCount = snapshot.WarningCount,
+                CurrentTitle = snapshot.CurrentTitle,
+                Percentage = snapshot.Percentage,
                 Error = ex.Message,
                 IsComplete = true
-            };
+            });
+
+            Console.Error.WriteLine($"Sort failed: {ex}");
         }
         finally
         {
@@ -110,6 +199,45 @@ public class SortService
                 _sortCancellation = null;
                 _isSorting = false;
             }
+        }
+    }
+
+    /// <summary>
+    /// Returns the loaded library, re-reading the CSV when nothing is loaded or when the caller
+    /// asked to sort a different file than the one in memory.
+    /// </summary>
+    private async Task<List<OpenAudible>> EnsureBooksLoaded(string csvPath, CancellationToken cancellationToken)
+    {
+        string? loadedPath;
+        List<OpenAudible> books;
+        lock (_sortLock)
+        {
+            loadedPath = _booksCsvPath;
+            books = _books;
+        }
+
+        var requestedPath = Path.GetFullPath(csvPath);
+        if (books.Count > 0 && string.Equals(loadedPath, requestedPath, StringComparison.OrdinalIgnoreCase))
+        {
+            return books;
+        }
+
+        var result = await _csvParser.ParseAsync(csvPath, cancellationToken);
+
+        lock (_sortLock)
+        {
+            _books = result.Books;
+            _booksCsvPath = requestedPath;
+        }
+
+        return result.Books;
+    }
+
+    private void SetProgress(SortProgressInfo progress)
+    {
+        lock (_sortLock)
+        {
+            _currentProgress = progress;
         }
     }
 }

--- a/ManagerApi/Services/SortService.cs
+++ b/ManagerApi/Services/SortService.cs
@@ -140,7 +140,10 @@ public class SortService
         {
             var books = await EnsureBooksLoaded(csvPath, cancellation.Token);
 
-            var progress = new Progress<SortProgressInfo>(SetProgress);
+            // Deliberately not Progress<T>: it marshals each report through the thread pool, so a
+            // per-book report could be delivered after the final one and leave the run looking
+            // unfinished forever.
+            var progress = new InlineProgress<SortProgressInfo>(SetProgress);
             var summary = await _fileSorter.SortAudioFiles(sourcePath, destinationPath, books, progress, cancellation.Token);
 
             SetProgress(new SortProgressInfo
@@ -233,11 +236,31 @@ public class SortService
         return result.Books;
     }
 
-    private void SetProgress(SortProgressInfo progress)
+    /// <summary>
+    /// Publishes a progress snapshot. Internal rather than private so the "a finished run stays
+    /// finished" guarantee can be tested without racing the thread pool.
+    /// </summary>
+    internal void SetProgress(SortProgressInfo progress)
     {
         lock (_sortLock)
         {
+            // Once a run is finished, nothing from that run may un-finish it. The UI stops
+            // polling on the completed flag, so losing it would leave it spinning forever.
+            if (_currentProgress.IsComplete && !progress.IsComplete)
+            {
+                return;
+            }
+
             _currentProgress = progress;
         }
+    }
+
+    /// <summary>
+    /// An <see cref="IProgress{T}"/> that invokes the handler on the reporting thread instead of
+    /// queueing it, so reports are applied in the order they were made.
+    /// </summary>
+    private sealed class InlineProgress<T>(Action<T> handler) : IProgress<T>
+    {
+        public void Report(T value) => handler(value);
     }
 }

--- a/OpenAudibleBookManager.sln
+++ b/OpenAudibleBookManager.sln
@@ -4,30 +4,61 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioFileSorter", "AudioFil
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ManagerApi", "ManagerApi\ManagerApi.csproj", "{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WatcherService", "WatcherService\WatcherService.csproj", "{C6D7E8F9-A0B1-2345-6789-CDEF01234567}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F7321B0A-493F-4A48-82B7-33C6C5A6558A}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AudioFileSorter.Tests", "AudioFileSorter.Tests\AudioFileSorter.Tests.csproj", "{7D395A9F-625C-4118-B701-00E41FCE4F58}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Debug|x64.Build.0 = Debug|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Debug|x86.Build.0 = Debug|Any CPU
 		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Release|x64.ActiveCfg = Release|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Release|x64.Build.0 = Release|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Release|x86.ActiveCfg = Release|Any CPU
+		{8BF2B66D-32CC-4607-BDBE-356659ED2082}.Release|x86.Build.0 = Release|Any CPU
 		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Debug|x64.Build.0 = Debug|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Debug|x86.Build.0 = Debug|Any CPU
 		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C6D7E8F9-A0B1-2345-6789-CDEF01234567}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C6D7E8F9-A0B1-2345-6789-CDEF01234567}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C6D7E8F9-A0B1-2345-6789-CDEF01234567}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C6D7E8F9-A0B1-2345-6789-CDEF01234567}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Release|x64.ActiveCfg = Release|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Release|x64.Build.0 = Release|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Release|x86.ActiveCfg = Release|Any CPU
+		{B5A1C2D3-E4F5-6789-ABCD-EF0123456789}.Release|x86.Build.0 = Release|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Debug|x64.Build.0 = Debug|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Debug|x86.Build.0 = Debug|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Release|x64.ActiveCfg = Release|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Release|x64.Build.0 = Release|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Release|x86.ActiveCfg = Release|Any CPU
+		{7D395A9F-625C-4118-B701-00E41FCE4F58}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -29,15 +29,22 @@ setting on the Sort page toggles between the two:
 | **Quick** (default) | File size, plus the first, middle and last 4 KB | Every day. It catches any re-release whose length changed, which is nearly all of them, and costs almost nothing to run over a large library. |
 | **Verify contents** | Every byte of both files | When you suspect a book was re-issued at exactly the same size, or you want certainty after a bad disk or an interrupted copy. Slower: it reads both files in full. |
 
-Either way, books that already match are left untouched and reported as skipped, and the sort
-summary shows how many books were **Updated** — replaced because their source had changed — as
-opposed to copied for the first time.
+Either way, a book that already matches is left untouched. The sort summary counts it as
+**Skipped**, along with any book whose source file could not be found at all, and reports
+**Updated** — books replaced because their source had changed — as a subset of **Copied**, which
+also includes books written to the destination for the first time.
 
 In Docker, set the default with the `COMPARISON_MODE` environment variable (`quick` or `full`);
 the Sort page can still override it for an individual run.
 
-Note that a re-release that also changes the book's *title* is filed under the new name, and the
-file under the old name is left alone; the organiser never deletes from your destination folder.
+Two things worth knowing about re-releases:
+
+- The organiser never deletes from your destination folder. If a re-release also changes the book's
+  title enough to be filed under a different name, the new file is written alongside the old one,
+  and removing the old copy is up to you. A title that differs only in punctuation or spacing still
+  resolves to the existing file, which is replaced in place as usual.
+- Replacing a book is atomic: the new version is written beside the old one and renamed over it, so
+  an interrupted update leaves you with either the old copy or the new one, never half of each.
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ Installers are output to `electron-ui/release/`.
 The web app container is published to GitHub Container Registry under GitHub Packages as:
 
 ```text
-ghcr.io/orbitalteapot/openaudible-book-organizer
+ghcr.io/orbitalteapot/openaudible-bookorganizer
 ```
+
+Note that the image name has no hyphen between "book" and "organizer".
 
 Available tags are published by the release workflow:
 
@@ -137,10 +139,14 @@ Available tags are published by the release workflow:
 - Major/minor version, for example `1.2`
 - `latest`
 
+A pre-release such as `3.1.0-beta.1` is published under its exact version only. `latest` and the
+major/minor tag keep pointing at the most recent stable release, so pulling `latest` never lands
+you on a beta by accident — you have to ask for the version by name.
+
 ### Pull the Image
 
 ```sh
-docker pull ghcr.io/orbitalteapot/openaudible-book-organizer:latest
+docker pull ghcr.io/orbitalteapot/openaudible-bookorganizer:latest
 ```
 
 ### How the Docker Image Works
@@ -228,7 +234,7 @@ docker run -d \
   -v /path/to/local/audiobooks:/source \
   -v /path/to/local/organized:/destination \
   --restart unless-stopped \
-  ghcr.io/orbitalteapot/openaudible-book-organizer:latest
+  ghcr.io/orbitalteapot/openaudible-bookorganizer:latest
 ```
 
 ### What to Do After the Container Starts
@@ -328,7 +334,7 @@ Example service using the published image:
 ```yaml
 services:
   book-organizer-web:
-    image: ghcr.io/orbitalteapot/openaudible-book-organizer:latest
+    image: ghcr.io/orbitalteapot/openaudible-bookorganizer:latest
     environment:
       CSV_PATH: /data/books.csv
       SOURCE_PATH: /source
@@ -359,7 +365,7 @@ http://localhost:5123
 The Docker image is published to GitHub Packages, not attached to the GitHub Release assets.
 
 - Repo owner packages page: `https://github.com/users/orbitalteapot/packages`
-- Package URL: `https://github.com/users/orbitalteapot/packages/container/package/openaudible-book-organizer`
+- Package URL: `https://github.com/users/orbitalteapot/packages/container/package/openaudible-bookorganizer`
 
 Depending on GitHub package visibility and linkage, it may appear under the owner Packages page before it appears in the repository sidebar.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,33 @@ Supported targets include Windows, Linux, macOS, and Docker.
 - Loads an OpenAudible CSV export
 - Organizes audiobook files into `Author / Series / Book` folders
 - Copies companion PDFs when they are available in the CSV metadata
+- Replaces books you have re-downloaded, so an organized library stays current
 - Ships as a desktop app and as a Docker image for watcher-based automation
+
+## Keeping Books Up To Date
+
+Publishers re-issue audiobooks: a corrected chapter, a re-recorded narration, an updated edition.
+When you download the new version, a sort should replace the copy already in your organized
+library rather than leave the old one sitting there.
+
+Every run compares each book against the copy at the destination and only writes when they differ,
+so re-running a sort is cheap and safe. How closely it compares is up to you — the **Update check**
+setting on the Sort page toggles between the two:
+
+| Update check | What it compares | When to use it |
+| --- | --- | --- |
+| **Quick** (default) | File size, plus the first, middle and last 4 KB | Every day. It catches any re-release whose length changed, which is nearly all of them, and costs almost nothing to run over a large library. |
+| **Verify contents** | Every byte of both files | When you suspect a book was re-issued at exactly the same size, or you want certainty after a bad disk or an interrupted copy. Slower: it reads both files in full. |
+
+Either way, books that already match are left untouched and reported as skipped, and the sort
+summary shows how many books were **Updated** — replaced because their source had changed — as
+opposed to copied for the first time.
+
+In Docker, set the default with the `COMPARISON_MODE` environment variable (`quick` or `full`);
+the Sort page can still override it for an individual run.
+
+Note that a re-release that also changes the book's *title* is filed under the new name, and the
+file under the old name is left alone; the organiser never deletes from your destination folder.
 
 ## Screenshots
 
@@ -125,6 +151,8 @@ Optional:
 - `OABO_MAX_PARALLELISM` sets how many books are copied at once. It defaults to a quarter of the
   available CPU cores, capped at 8. Lower it to `1` or `2` if the destination is a network share
   or a spinning disk, where more concurrency makes transfers slower rather than faster.
+- `COMPARISON_MODE` sets the default update check, `quick` (the default) or `full`. See
+  [Keeping books up to date](#keeping-books-up-to-date). The Sort page can override it per run.
 
 ### How the Website Works
 
@@ -178,6 +206,7 @@ The container expects these environment variables:
 - `CSV_PATH=/data/books.csv`
 - `SOURCE_PATH=/source`
 - `DESTINATION_PATH=/destination`
+- `COMPARISON_MODE=quick` (optional; use `full` to compare every byte)
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ npm install
 npm run dev
 ```
 
+### Run the Tests
+
+The sorting engine is covered by a test suite that runs on Linux, macOS, and Windows:
+
+```sh
+dotnet test OpenAudibleBookManager.sln
+```
+
+It exercises path sanitisation, author and series folder resolution, planning determinism,
+atomic and repeatable copying, cancellation, and CSV import robustness.
+
 ### Build Installers
 
 ```sh
@@ -108,6 +119,12 @@ At startup and while running, it uses:
 - `CSV_PATH` to load book metadata from your OpenAudible export
 - `SOURCE_PATH` as the mounted source folder that contains your audiobook files
 - `DESTINATION_PATH` as the folder where organized books are written
+
+Optional:
+
+- `OABO_MAX_PARALLELISM` sets how many books are copied at once. It defaults to a quarter of the
+  available CPU cores, capped at 8. Lower it to `1` or `2` if the destination is a network share
+  or a spinning disk, where more concurrency makes transfers slower rather than faster.
 
 ### How the Website Works
 
@@ -263,7 +280,7 @@ docker restart openaudible-book-organizer
 
 ### Use docker-compose.yml
 
-This repository already includes a sample [docker-compose.yml](d:/Development/test/newtest/OpenAudible-BookOrganizer/docker-compose.yml).
+This repository already includes a sample [docker-compose.yml](docker-compose.yml).
 
 1. Put your OpenAudible CSV export in `./data/books.csv`.
 2. Replace the example source and destination mount paths with your real folders.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
       SOURCE_PATH: /source
       # Path inside the container where sorted books are written
       DESTINATION_PATH: /destination
+      # Default update check: "quick" (size and sampled contents) or "full" (every byte).
+      # The Sort page can override this for an individual run.
+      COMPARISON_MODE: quick
     ports:
       - "5123:5123"
     volumes:

--- a/electron-ui/electron/main.js
+++ b/electron-ui/electron/main.js
@@ -119,10 +119,12 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1320,
     height: 860,
-    minWidth: 960,
-    minHeight: 640,
+    // The layout sheds the sidebar labels and the optional table columns below this, so the
+    // window stays usable rather than needing a horizontal scrollbar.
+    minWidth: 720,
+    minHeight: 560,
     frame: false,
-    backgroundColor: '#0f172a',
+    backgroundColor: '#0c0e11',
     show: false,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),

--- a/electron-ui/electron/main.js
+++ b/electron-ui/electron/main.js
@@ -3,87 +3,115 @@ const path = require('path');
 const fs = require('fs');
 const { spawn } = require('child_process');
 
-let mainWindow;
-let backendProcess;
+const BACKEND_URL = 'http://localhost:5123';
+const BACKEND_START_TIMEOUT_MS = 60_000;
+const BACKEND_POLL_INTERVAL_MS = 500;
 
-function getBackendExecutable() {
-  const isDev = !app.isPackaged;
-  if (isDev) return null; // handled differently in dev
+let mainWindow = null;
+let backendProcess = null;
+let backendExit = null; // { code, signal } once the backend has stopped
+let quitting = false;
 
-  const platform = process.platform;
-  const backendDir = path.join(process.resourcesPath, 'backend');
-
-  if (platform === 'win32') return path.join(backendDir, 'ManagerApi.exe');
-  return path.join(backendDir, 'ManagerApi'); // linux & mac
+function isDev() {
+  return !app.isPackaged;
 }
 
-function startBackend() {
-  const isDev = !app.isPackaged;
+function getBackendExecutable() {
+  const backendDir = path.join(process.resourcesPath, 'backend');
+  return process.platform === 'win32'
+    ? path.join(backendDir, 'ManagerApi.exe')
+    : path.join(backendDir, 'ManagerApi');
+}
 
-  if (isDev) {
-    // In dev, check if backend is already running, else spawn dotnet run
-    fetch('http://localhost:5123/api/health')
-      .then(() => {
-        console.log('[API] Backend already running');
-      })
-      .catch(() => {
-        console.log('[API] Starting backend via dotnet run...');
-        backendProcess = spawn('dotnet', [
-          'run', '--project',
-          path.join(__dirname, '../../ManagerApi/ManagerApi.csproj')
-        ], { stdio: 'pipe' });
+function attachProcessLogging(child) {
+  child.stdout?.on('data', (data) => console.log(`[API] ${data.toString().trim()}`));
+  child.stderr?.on('data', (data) => console.error(`[API] ${data.toString().trim()}`));
 
-        backendProcess.stdout.on('data', (data) => {
-          console.log(`[API] ${data.toString().trim()}`);
-        });
+  child.on('error', (err) => {
+    console.error('[API] Failed to start backend:', err.message);
+    backendExit = { code: null, signal: null, error: err.message };
+  });
 
-        backendProcess.stderr.on('data', (data) => {
-          console.error(`[API] ${data.toString().trim()}`);
-        });
+  // Without this, a backend that dies mid-session leaves the UI waiting forever on requests
+  // that will never be answered.
+  child.on('exit', (code, signal) => {
+    console.error(`[API] Backend exited (code ${code}, signal ${signal})`);
+    backendExit = { code, signal };
+    backendProcess = null;
 
-        backendProcess.on('error', (err) => {
-          console.error('Failed to start backend:', err.message);
-        });
+    if (!quitting && mainWindow && !mainWindow.isDestroyed()) {
+      dialog.showMessageBox(mainWindow, {
+        type: 'error',
+        title: 'Backend stopped',
+        message: 'The Book Organizer backend stopped unexpectedly.',
+        detail:
+          'Sorting and library loading will not work until the app is restarted. ' +
+          `Exit code: ${code === null ? signal : code}`,
+        buttons: ['OK'],
       });
+    }
+  });
+}
+
+async function isBackendReachable() {
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/health`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function startBackend() {
+  // Someone may already be running the backend by hand (the documented dev workflow), in which
+  // case starting a second one would just fail on the port and confuse the logs.
+  if (await isBackendReachable()) {
+    console.log('[API] Backend already running');
+    return;
+  }
+
+  if (isDev()) {
+    console.log('[API] Starting backend via dotnet run...');
+    backendProcess = spawn(
+      'dotnet',
+      ['run', '--project', path.join(__dirname, '../../ManagerApi/ManagerApi.csproj')],
+      { stdio: 'pipe' }
+    );
   } else {
-    // In production, launch the self-contained binary
     const exe = getBackendExecutable();
     console.log(`[API] Starting backend: ${exe}`);
 
-    // Ensure the binary is executable on Linux/macOS
-    if (process.platform !== 'win32') {
-      try { fs.chmodSync(exe, 0o755); } catch { /* best effort */ }
+    if (!fs.existsSync(exe)) {
+      backendExit = { code: null, signal: null, error: `Backend executable not found at ${exe}` };
+      return;
     }
 
-    backendProcess = spawn(exe, [], {
-      stdio: 'pipe',
-      env: { ...process.env },
-    });
+    if (process.platform !== 'win32') {
+      try {
+        fs.chmodSync(exe, 0o755);
+      } catch {
+        // Best effort; the spawn below reports the real problem if it is not executable.
+      }
+    }
 
-    backendProcess.stdout.on('data', (data) => {
-      console.log(`[API] ${data.toString().trim()}`);
-    });
-
-    backendProcess.stderr.on('data', (data) => {
-      console.error(`[API] ${data.toString().trim()}`);
-    });
-
-    backendProcess.on('error', (err) => {
-      console.error('Failed to start backend:', err.message);
-    });
+    backendProcess = spawn(exe, [], { stdio: 'pipe', env: { ...process.env } });
   }
+
+  attachProcessLogging(backendProcess);
 }
 
-async function waitForBackend(maxRetries = 40) {
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      const response = await fetch('http://localhost:5123/api/health');
-      if (response.ok) return true;
-    } catch {
-      // Backend not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 1000));
+async function waitForBackend() {
+  const deadline = Date.now() + BACKEND_START_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    if (await isBackendReachable()) return true;
+
+    // No point waiting out the full timeout for a process that has already died.
+    if (backendExit) return false;
+
+    await new Promise((resolve) => setTimeout(resolve, BACKEND_POLL_INTERVAL_MS));
   }
+
   return false;
 }
 
@@ -103,32 +131,31 @@ function createWindow() {
     },
   });
 
-  const isDev = !app.isPackaged;
-
-  if (isDev) {
+  if (isDev()) {
     mainWindow.loadURL('http://localhost:5173');
   } else {
     mainWindow.loadFile(path.join(__dirname, '../dist/index.html'));
   }
 
-  mainWindow.once('ready-to-show', () => {
-    mainWindow.show();
+  mainWindow.once('ready-to-show', () => mainWindow?.show());
+  mainWindow.on('closed', () => {
+    mainWindow = null;
   });
 }
 
-app.whenReady().then(async () => {
-  startBackend();
+function withWindow(action) {
+  return () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      return action(mainWindow);
+    }
+    return null;
+  };
+}
 
-  console.log('Waiting for backend...');
-  const backendReady = await waitForBackend();
-  if (!backendReady) {
-    console.error('Backend did not start in time');
-  }
-
-  createWindow();
-
-  // IPC: File dialog
+function registerIpcHandlers() {
   ipcMain.handle('dialog:openFile', async (_, filters) => {
+    if (!mainWindow || mainWindow.isDestroyed()) return null;
+
     const result = await dialog.showOpenDialog(mainWindow, {
       properties: ['openFile'],
       filters: filters || [{ name: 'CSV Files', extensions: ['csv'] }],
@@ -136,48 +163,81 @@ app.whenReady().then(async () => {
     return result.canceled ? null : result.filePaths[0];
   });
 
-  // IPC: Folder dialog
   ipcMain.handle('dialog:openFolder', async () => {
-    const result = await dialog.showOpenDialog(mainWindow, {
-      properties: ['openDirectory'],
-    });
+    if (!mainWindow || mainWindow.isDestroyed()) return null;
+
+    const result = await dialog.showOpenDialog(mainWindow, { properties: ['openDirectory'] });
     return result.canceled ? null : result.filePaths[0];
   });
 
-  // IPC: Window controls
-  ipcMain.handle('window:minimize', () => mainWindow.minimize());
-  ipcMain.handle('window:maximize', () => {
-    if (mainWindow.isMaximized()) {
-      mainWindow.unmaximize();
-    } else {
-      mainWindow.maximize();
+  ipcMain.handle('window:minimize', withWindow((window) => window.minimize()));
+  ipcMain.handle(
+    'window:maximize',
+    withWindow((window) => (window.isMaximized() ? window.unmaximize() : window.maximize()))
+  );
+  ipcMain.handle('window:close', withWindow((window) => window.close()));
+  ipcMain.handle('window:isMaximized', withWindow((window) => window.isMaximized()));
+}
+
+// Two copies of the app would both try to own port 5123, and the loser would look broken.
+if (!app.requestSingleInstanceLock()) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
     }
   });
-  ipcMain.handle('window:close', () => mainWindow.close());
-  ipcMain.handle('window:isMaximized', () => mainWindow.isMaximized());
-});
+
+  app.whenReady().then(async () => {
+    registerIpcHandlers();
+    await startBackend();
+
+    console.log('Waiting for backend...');
+    const backendReady = await waitForBackend();
+
+    createWindow();
+
+    if (!backendReady) {
+      console.error('Backend did not start in time');
+      dialog.showMessageBox(mainWindow, {
+        type: 'error',
+        title: 'Backend did not start',
+        message: 'The Book Organizer backend could not be started.',
+        detail:
+          backendExit?.error ||
+          'Check that port 5123 is free and that no other copy of the app is running, then restart the app.',
+        buttons: ['OK'],
+      });
+    }
+  });
+}
 
 function killBackend() {
-  if (backendProcess) {
-    try {
-      // On Windows, child processes need tree-kill via taskkill
-      if (process.platform === 'win32') {
-        spawn('taskkill', ['/pid', String(backendProcess.pid), '/f', '/t']);
-      } else {
-        backendProcess.kill('SIGTERM');
-      }
-    } catch {
-      // Best effort
+  if (!backendProcess) return;
+
+  const child = backendProcess;
+  backendProcess = null;
+
+  try {
+    if (process.platform === 'win32') {
+      spawn('taskkill', ['/pid', String(child.pid), '/f', '/t']);
+    } else {
+      child.kill('SIGTERM');
     }
-    backendProcess = null;
+  } catch {
+    // Best effort.
   }
 }
 
 app.on('window-all-closed', () => {
+  quitting = true;
   killBackend();
   app.quit();
 });
 
 app.on('before-quit', () => {
+  quitting = true;
   killBackend();
 });

--- a/electron-ui/index.html
+++ b/electron-ui/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:5123; img-src 'self' data: https:;" />
+    <!-- Inline so it needs no network request and stays within the self-only CSP. -->
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23588fff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 14v-2a9 9 0 0 1 18 0v2'/%3E%3Cpath d='M3 14h3v6H5a2 2 0 0 1-2-2z'/%3E%3Cpath d='M21 14h-3v6h1a2 2 0 0 0 2-2z'/%3E%3C/svg%3E"
+    />
     <title>OpenAudible Book Organizer</title>
   </head>
   <body>

--- a/electron-ui/package-lock.json
+++ b/electron-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openaudible-book-organizer",
-  "version": "1.0.0",
+  "version": "3.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openaudible-book-organizer",
-      "version": "1.0.0",
+      "version": "3.1.0-beta.1",
       "license": "GPL-3.0-only",
       "dependencies": {
         "lucide-react": "^0.300.0",
@@ -18,10 +18,8 @@
         "autoprefixer": "^10.4.16",
         "concurrently": "^8.2.2",
         "electron": "^39.8.5",
-        "electron-builder": "^26.8.1",
-        "electron": "^35.7.5",
         "electron-builder": "^26.15.3",
-        "postcss": "^8.4.32",
+        "postcss": "^8.5.25",
         "tailwindcss": "^3.4.0",
         "vite": "^8.0.16",
         "wait-on": "^7.2.0"
@@ -2504,9 +2502,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "39.8.5",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.5.tgz",
-      "integrity": "sha512-q6+LiQIcTadSyvtPgLDQkCtVA9jQJXQVMrQcctfOJILh6OFMN+UJJLRkuUTy8CZDYeCIBn1ZycqsL1dAXugxZA==",
+      "version": "39.8.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.8.10.tgz",
+      "integrity": "sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3527,10 +3525,11 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -4119,9 +4118,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4493,12 +4492,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4516,8 +4512,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/electron-ui/package-lock.json
+++ b/electron-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openaudible-book-organizer",
-  "version": "3.1.0-beta.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openaudible-book-organizer",
-      "version": "3.1.0-beta.1",
+      "version": "1.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
         "lucide-react": "^0.300.0",
@@ -22,6 +22,7 @@
         "postcss": "^8.5.25",
         "tailwindcss": "^3.4.0",
         "vite": "^8.0.16",
+        "vitest": "^4.1.10",
         "wait-on": "^7.2.0"
       }
     },
@@ -1075,6 +1076,13 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
@@ -1110,6 +1118,17 @@
         "@types/responselike": "^1.0.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1119,6 +1138,20 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.13",
@@ -1205,6 +1238,119 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -1504,6 +1650,16 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -1923,6 +2079,16 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2129,6 +2295,13 @@
       "funding": {
         "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2743,6 +2916,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -2797,6 +2977,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -3951,6 +4151,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
@@ -4327,6 +4537,20 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4386,6 +4610,13 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
@@ -5172,6 +5403,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -5246,6 +5484,13 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -5255,6 +5500,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
@@ -5531,6 +5783,23 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5576,6 +5845,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -5866,6 +6145,109 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/wait-on": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
@@ -5913,6 +6295,23 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -37,10 +37,8 @@
     "autoprefixer": "^10.4.16",
     "concurrently": "^8.2.2",
     "electron": "^39.8.5",
-    "electron-builder": "^26.8.1",
-    "postcss": "^8.5.25",
     "electron-builder": "^26.15.3",
-    "postcss": "^8.4.32",
+    "postcss": "^8.5.25",
     "tailwindcss": "^3.4.0",
     "vite": "^8.0.16",
     "wait-on": "^7.2.0"

--- a/electron-ui/package.json
+++ b/electron-ui/package.json
@@ -13,6 +13,7 @@
     "email": "orbital@teapot.no"
   },
   "main": "electron/main.js",
+  "desktopName": "openaudible-book-organizer",
   "scripts": {
     "dev": "concurrently -n vite,electron \"vite\" \"wait-on http://localhost:5173 && electron .\"",
     "build": "vite build",
@@ -25,7 +26,8 @@
     "dist:linux": "npm run publish:backend:linux && vite build && electron-builder --publish never --linux",
     "dist:mac-x64": "npm run publish:backend:mac && vite build && electron-builder --publish never --mac --x64",
     "dist:mac-arm": "npm run publish:backend:mac-arm && vite build && electron-builder --publish never --mac --arm64",
-    "dist:all": "npm run publish:backend:win && npm run publish:backend:linux && npm run publish:backend:mac && npm run publish:backend:mac-arm && vite build && electron-builder --publish never --win --linux --mac --x64 --arm64"
+    "dist:all": "npm run publish:backend:win && npm run publish:backend:linux && npm run publish:backend:mac && npm run publish:backend:mac-arm && vite build && electron-builder --publish never --win --linux --mac --x64 --arm64",
+    "test": "vitest run"
   },
   "dependencies": {
     "lucide-react": "^0.300.0",
@@ -41,6 +43,7 @@
     "postcss": "^8.5.25",
     "tailwindcss": "^3.4.0",
     "vite": "^8.0.16",
+    "vitest": "^4.1.10",
     "wait-on": "^7.2.0"
   },
   "build": {
@@ -56,10 +59,21 @@
     "win": {
       "artifactName": "OpenAudible-Book-Organizer-${version}-windows-${arch}.${ext}",
       "target": [
-        { "target": "nsis", "arch": ["x64"] }
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
       ],
       "extraResources": [
-        { "from": "backend-bin/win-x64", "to": "backend", "filter": ["**/*"] }
+        {
+          "from": "backend-bin/win-x64",
+          "to": "backend",
+          "filter": [
+            "**/*"
+          ]
+        }
       ]
     },
     "nsis": {
@@ -70,29 +84,67 @@
     "linux": {
       "artifactName": "OpenAudible-Book-Organizer-${version}-linux-${arch}.${ext}",
       "target": [
-        { "target": "AppImage", "arch": ["x64"] },
-        { "target": "deb", "arch": ["x64"] }
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64"
+          ]
+        }
       ],
       "category": "Utility",
       "maintainer": "orbitalteapot <orbital@teapot.no>",
       "extraResources": [
-        { "from": "backend-bin/linux-x64", "to": "backend", "filter": ["**/*"] }
-      ]
+        {
+          "from": "backend-bin/linux-x64",
+          "to": "backend",
+          "filter": [
+            "**/*"
+          ]
+        }
+      ],
+      "synopsis": "Organize an OpenAudible export into Author / Series / Book folders",
+      "syncDesktopName": true
     },
     "mac": {
       "artifactName": "OpenAudible-Book-Organizer-${version}-macos-${arch}.${ext}",
       "target": [
-        { "target": "dmg", "arch": ["x64", "arm64"] }
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
       "category": "public.app-category.utilities",
       "extraResources": [
-        { "from": "backend-bin/osx-${arch}", "to": "backend", "filter": ["**/*"] }
+        {
+          "from": "backend-bin/osx-${arch}",
+          "to": "backend",
+          "filter": [
+            "**/*"
+          ]
+        }
       ]
     },
     "dmg": {
       "contents": [
-        { "x": 130, "y": 220 },
-        { "x": 410, "y": 220, "type": "link", "path": "/Applications" }
+        {
+          "x": 130,
+          "y": 220
+        },
+        {
+          "x": 410,
+          "y": 220,
+          "type": "link",
+          "path": "/Applications"
+        }
       ]
     }
   }

--- a/electron-ui/src/App.jsx
+++ b/electron-ui/src/App.jsx
@@ -18,6 +18,7 @@ export default function App() {
     csvPath: '',
     sourcePath: '',
     destPath: '',
+    comparisonMode: 'quick',
     sorting: false,
     progress: null,
     error: null,
@@ -39,6 +40,7 @@ export default function App() {
           csvPath: config.csvPath || prev.csvPath,
           sourcePath: config.sourcePath || prev.sourcePath,
           destPath: config.destinationPath || prev.destPath,
+          comparisonMode: config.comparisonMode || prev.comparisonMode,
         }));
       })
       .catch(() => {

--- a/electron-ui/src/App.jsx
+++ b/electron-ui/src/App.jsx
@@ -1,50 +1,53 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import TitleBar from './components/TitleBar';
 import Sidebar from './components/Sidebar';
 import Library from './components/Library';
 import SortPanel from './components/SortPanel';
 import { getAppConfig } from './api';
+import { useIsElectron } from './hooks';
+
+const INITIAL_CONFIG = {
+  csvPath: '',
+  sourcePath: '',
+  destPath: '',
+  comparisonMode: 'quick',
+};
+
+const INITIAL_RUN = {
+  sorting: false,
+  progress: null,
+  error: null,
+};
 
 export default function App() {
+  const isElectron = useIsElectron();
   const [currentPage, setCurrentPage] = useState('library');
   const [books, setBooks] = useState([]);
-  const [configLoaded, setConfigLoaded] = useState(false);
+  const [configLoaded, setConfigLoaded] = useState(isElectron);
 
-  const isBrowser = typeof window !== 'undefined';
-  const isElectron = isBrowser && !!window.electronAPI;
-
-  // Sort state lifted here so it persists across page switches
-  const [sortState, setSortState] = useState({
-    csvPath: '',
-    sourcePath: '',
-    destPath: '',
-    comparisonMode: 'quick',
-    sorting: false,
-    progress: null,
-    error: null,
-  });
+  // Deliberately two pieces of state. `run` changes two and a half times a second while a sort is
+  // going; `config` does not. Keeping them apart, with the pages memoised, means that polling
+  // re-renders the progress card and nothing else.
+  const [config, setConfig] = useState(INITIAL_CONFIG);
+  const [run, setRun] = useState(INITIAL_RUN);
 
   useEffect(() => {
-    if (isElectron) {
-      setConfigLoaded(true);
-      return;
-    }
+    if (isElectron) return undefined;
 
     let active = true;
 
     getAppConfig()
-      .then((config) => {
+      .then((serverConfig) => {
         if (!active) return;
-        setSortState((prev) => ({
-          ...prev,
-          csvPath: config.csvPath || prev.csvPath,
-          sourcePath: config.sourcePath || prev.sourcePath,
-          destPath: config.destinationPath || prev.destPath,
-          comparisonMode: config.comparisonMode || prev.comparisonMode,
+        setConfig((prev) => ({
+          csvPath: serverConfig.csvPath || prev.csvPath,
+          sourcePath: serverConfig.sourcePath || prev.sourcePath,
+          destPath: serverConfig.destinationPath || prev.destPath,
+          comparisonMode: serverConfig.comparisonMode || prev.comparisonMode,
         }));
       })
       .catch(() => {
-        // The API panel will surface request failures when actions are invoked.
+        // Surfaced when an action is actually attempted; a failed probe on load is just noise.
       })
       .finally(() => {
         if (active) setConfigLoaded(true);
@@ -55,36 +58,24 @@ export default function App() {
     };
   }, [isElectron]);
 
+  const handlePageChange = useCallback((page) => setCurrentPage(page), []);
+
   if (!configLoaded) {
-    return <div className="h-screen bg-slate-900" />;
+    return <div className="h-full bg-canvas" />;
   }
 
   return (
-    <div className="h-screen flex flex-col bg-slate-900">
+    <div className="flex h-full flex-col bg-canvas">
       <TitleBar />
 
-      <div className="flex flex-1 min-h-0">
-        <Sidebar
-          currentPage={currentPage}
-          onPageChange={setCurrentPage}
-          bookCount={books.length}
-        />
+      <div className="flex min-h-0 flex-1">
+        <Sidebar currentPage={currentPage} onPageChange={handlePageChange} bookCount={books.length} />
 
-        <main className="flex-1 flex flex-col min-w-0 p-6">
-          {currentPage === 'library' && (
-            <Library
-              books={books}
-              setBooks={setBooks}
-              sortState={sortState}
-              setSortState={setSortState}
-            />
-          )}
-          {currentPage === 'sort' && (
-            <SortPanel
-              books={books}
-              sortState={sortState}
-              setSortState={setSortState}
-            />
+        <main className="flex min-w-0 flex-1 flex-col p-5">
+          {currentPage === 'library' ? (
+            <Library books={books} setBooks={setBooks} csvPath={config.csvPath} />
+          ) : (
+            <SortPanel config={config} setConfig={setConfig} run={run} setRun={setRun} />
           )}
         </main>
       </div>

--- a/electron-ui/src/api.js
+++ b/electron-ui/src/api.js
@@ -3,62 +3,99 @@ const isElectron = isBrowser && !!window.electronAPI;
 const isViteDev = isBrowser && window.location.port === '5173';
 const API_BASE = isElectron || isViteDev ? 'http://localhost:5123' : '';
 
+/**
+ * Pulls the error message out of a failed response. The backend answers with JSON, but a crashed
+ * or not-yet-started backend answers with HTML or nothing at all, and letting res.json() throw
+ * there replaces a useful message with a JSON parse error.
+ */
+async function readError(res) {
+  try {
+    const text = await res.text();
+    if (!text) return `Request failed (HTTP ${res.status})`;
+
+    try {
+      const parsed = JSON.parse(text);
+      return parsed?.error || `Request failed (HTTP ${res.status})`;
+    } catch {
+      return `Request failed (HTTP ${res.status})`;
+    }
+  } catch {
+    return `Request failed (HTTP ${res.status})`;
+  }
+}
+
+async function requestJson(path, options, fallbackMessage) {
+  let res;
+  try {
+    res = await fetch(`${API_BASE}${path}`, options);
+  } catch {
+    throw new Error('Could not reach the backend. Check that it is still running.');
+  }
+
+  if (!res.ok) {
+    throw new Error((await readError(res)) || fallbackMessage);
+  }
+
+  return res.json();
+}
+
 export async function healthCheck() {
-  const res = await fetch(`${API_BASE}/api/health`);
-  return res.ok;
+  try {
+    const res = await fetch(`${API_BASE}/api/health`);
+    return res.ok;
+  } catch {
+    return false;
+  }
 }
 
 export async function parseBooks(csvPath) {
-  const res = await fetch(`${API_BASE}/api/books/parse`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ csvPath }),
-  });
-  if (!res.ok) {
-    const err = await res.json();
-    throw new Error(err.error || 'Failed to parse books');
+  const data = await requestJson(
+    '/api/books/parse',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ csvPath }),
+    },
+    'Failed to parse books'
+  );
+
+  // Older backends replied with a bare array of books.
+  if (Array.isArray(data)) {
+    return { books: data, skippedRows: 0, warnings: [] };
   }
-  return res.json();
+
+  return {
+    books: data?.books ?? [],
+    skippedRows: data?.skippedRows ?? 0,
+    warnings: data?.warnings ?? [],
+  };
 }
 
 export async function getBooks() {
-  const res = await fetch(`${API_BASE}/api/books`);
-  return res.json();
+  const data = await requestJson('/api/books', undefined, 'Failed to load books');
+  return Array.isArray(data) ? data : [];
 }
 
-export async function startSort(csvPath, sourcePath, destinationPath) {
-  const res = await fetch(`${API_BASE}/api/sort/start`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ csvPath, sourcePath, destinationPath }),
-  });
-  if (!res.ok) {
-    const err = await res.json();
-    throw new Error(err.error || 'Failed to start sort');
-  }
-  return res.json();
+export function startSort(csvPath, sourcePath, destinationPath) {
+  return requestJson(
+    '/api/sort/start',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ csvPath, sourcePath, destinationPath }),
+    },
+    'Failed to start sort'
+  );
 }
 
-export async function getSortProgress() {
-  const res = await fetch(`${API_BASE}/api/sort/progress`);
-  return res.json();
+export function getSortProgress() {
+  return requestJson('/api/sort/progress', undefined, 'Failed to read progress');
 }
 
-export async function cancelSort() {
-  const res = await fetch(`${API_BASE}/api/sort/cancel`, {
-    method: 'POST',
-  });
-  if (!res.ok) {
-    const err = await res.json();
-    throw new Error(err.error || 'Failed to cancel sort');
-  }
-  return res.json();
+export function cancelSort() {
+  return requestJson('/api/sort/cancel', { method: 'POST' }, 'Failed to cancel sort');
 }
 
-export async function getAppConfig() {
-  const res = await fetch(`${API_BASE}/api/config`);
-  if (!res.ok) {
-    throw new Error('Failed to load app configuration');
-  }
-  return res.json();
+export function getAppConfig() {
+  return requestJson('/api/config', undefined, 'Failed to load app configuration');
 }

--- a/electron-ui/src/api.js
+++ b/electron-ui/src/api.js
@@ -76,13 +76,17 @@ export async function getBooks() {
   return Array.isArray(data) ? data : [];
 }
 
-export function startSort(csvPath, sourcePath, destinationPath) {
+/**
+ * @param comparisonMode 'quick' | 'full'. Omitted lets the backend pick its default, which keeps
+ * this working against a backend that predates the setting.
+ */
+export function startSort(csvPath, sourcePath, destinationPath, comparisonMode) {
   return requestJson(
     '/api/sort/start',
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ csvPath, sourcePath, destinationPath }),
+      body: JSON.stringify({ csvPath, sourcePath, destinationPath, comparisonMode }),
     },
     'Failed to start sort'
   );

--- a/electron-ui/src/components/Library.jsx
+++ b/electron-ui/src/components/Library.jsx
@@ -1,32 +1,34 @@
-import { useState, useMemo } from 'react';
-import {
-  Search,
-  FileUp,
-  ChevronUp,
-  ChevronDown,
-  BookOpen,
-  Star,
-  Clock,
-  User,
-} from 'lucide-react';
+import { memo, useCallback, useMemo, useState } from 'react';
+import { BookOpen, FileUp, Search } from 'lucide-react';
 import { parseBooks } from '../api';
+import { useDebounced, useIsElectron } from '../hooks';
+import Button from './ui/Button';
+import { TextInput } from './ui/Field';
+import { Banner, EmptyState } from './ui/Surface';
+import LibraryTable from './LibraryTable';
 
-export default function LibraryView({ books, setBooks, sortState }) {
+const SEARCH_FIELDS = ['title', 'author', 'seriesName', 'narratedBy'];
+
+// Natural ordering, so "Book 2" sorts before "Book 10" and accented names file where a reader
+// expects. Built once rather than per comparison: constructing a collator is not cheap, and doing
+// it inside the sort callback made large libraries noticeably slow to reorder.
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+function LibraryView({ books, setBooks, csvPath }) {
+  const isElectron = useIsElectron();
   const [search, setSearch] = useState('');
-  const [sortField, setSortField] = useState('title');
-  const [sortDir, setSortDir] = useState('asc');
+  const [sort, setSort] = useState({ field: 'title', dir: 'asc' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [notice, setNotice] = useState(null);
-  const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
 
-  const handleLoadCsv = async () => {
-    let filePath = sortState?.csvPath;
+  const debouncedSearch = useDebounced(search);
+
+  const handleLoadCsv = useCallback(async () => {
+    let filePath = csvPath;
 
     if (isElectron) {
-      filePath = await window.electronAPI?.openFile([
-        { name: 'CSV Files', extensions: ['csv'] },
-      ]);
+      filePath = await window.electronAPI?.openFile([{ name: 'CSV Files', extensions: ['csv'] }]);
       if (!filePath) return;
     } else if (!filePath) {
       setError('No CSV path is configured for web mode');
@@ -36,6 +38,7 @@ export default function LibraryView({ books, setBooks, sortState }) {
     setLoading(true);
     setError(null);
     setNotice(null);
+
     try {
       const { books: loaded, skippedRows } = await parseBooks(filePath);
       setBooks(loaded);
@@ -53,211 +56,112 @@ export default function LibraryView({ books, setBooks, sortState }) {
     } finally {
       setLoading(false);
     }
-  };
+  }, [csvPath, isElectron, setBooks]);
 
-  const handleSort = (field) => {
-    if (sortField === field) {
-      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
-    } else {
-      setSortField(field);
-      setSortDir('asc');
-    }
-  };
+  const handleSort = useCallback((field) => {
+    setSort((prev) => (prev.field === field ? { field, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { field, dir: 'asc' }));
+  }, []);
 
-  const SortIcon = ({ field }) => {
-    if (sortField !== field) return <ChevronUp size={12} className="opacity-0 group-hover:opacity-30" />;
-    return sortDir === 'asc' ? (
-      <ChevronUp size={12} className="text-brand-400" />
-    ) : (
-      <ChevronDown size={12} className="text-brand-400" />
-    );
-  };
-
+  // Filtering and sorting are separate passes so that typing does not pay for a re-sort and
+  // re-sorting does not pay for a re-filter.
   const filtered = useMemo(() => {
-    let result = [...books];
+    const query = debouncedSearch.trim().toLowerCase();
+    if (!query) return books;
 
-    if (search.trim()) {
-      const q = search.toLowerCase();
-      result = result.filter(
-        (b) =>
-          b.title?.toLowerCase().includes(q) ||
-          b.author?.toLowerCase().includes(q) ||
-          b.seriesName?.toLowerCase().includes(q) ||
-          b.narratedBy?.toLowerCase().includes(q)
-      );
-    }
+    return books.filter((book) =>
+      SEARCH_FIELDS.some((field) => book[field]?.toLowerCase().includes(query))
+    );
+  }, [books, debouncedSearch]);
 
-    result.sort((a, b) => {
-      const aVal = (a[sortField] || '').toString().toLowerCase();
-      const bVal = (b[sortField] || '').toString().toLowerCase();
-      const cmp = aVal.localeCompare(bVal);
-      return sortDir === 'asc' ? cmp : -cmp;
+  const rows = useMemo(() => {
+    const { field, dir } = sort;
+    const sorted = [...filtered];
+
+    sorted.sort((a, b) => {
+      const left = a[field];
+      const right = b[field];
+
+      // Books missing the sorted-on value collect at the end either way, rather than forming a
+      // block of blanks at the top when the direction flips.
+      if (left == null || left === '') return right == null || right === '' ? 0 : 1;
+      if (right == null || right === '') return -1;
+
+      const comparison =
+        typeof left === 'number' && typeof right === 'number'
+          ? left - right
+          : collator.compare(String(left), String(right));
+
+      return dir === 'asc' ? comparison : -comparison;
     });
 
-    return result;
-  }, [books, search, sortField, sortDir]);
+    return sorted;
+  }, [filtered, sort]);
 
-  // Empty state
   if (books.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <div className="text-center max-w-md">
-          <div className="mx-auto w-20 h-20 rounded-2xl bg-gradient-to-br from-brand-500/20 to-violet-500/20 border border-brand-500/20 flex items-center justify-center mb-6">
-            <BookOpen size={36} className="text-brand-400" />
-          </div>
-          <h2 className="text-xl font-bold text-white mb-2">No audiobooks loaded</h2>
-          <p className="text-sm text-slate-400 mb-8 leading-relaxed">
-            {isElectron
-              ? 'Import your OpenAudible CSV export to see your library here. You can then browse, search, and sort your audiobook collection.'
-              : 'Load the configured OpenAudible CSV export to browse your library and trigger sorting from the web interface.'}
-          </p>
-          {!isElectron && sortState?.csvPath && (
-            <p className="mb-4 text-xs text-slate-500 bg-slate-800/50 border border-slate-700/30 rounded-lg px-4 py-2 break-all">
-              CSV: {sortState.csvPath}
-            </p>
-          )}
-          <button onClick={handleLoadCsv} disabled={loading} className="btn-primary inline-flex items-center gap-2">
-            <FileUp size={16} />
-            {loading ? 'Loading...' : isElectron ? 'Load CSV Export' : 'Load Library'}
-          </button>
-          {error && (
-            <p className="mt-4 text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
-              {error}
-            </p>
-          )}
-          {notice && (
-            <p className="mt-4 text-sm text-amber-300 bg-amber-500/10 border border-amber-500/20 rounded-lg px-4 py-2">
-              {notice}
-            </p>
-          )}
-        </div>
-      </div>
+      <EmptyState
+        icon={BookOpen}
+        title="No audiobooks loaded"
+        description={
+          isElectron
+            ? 'Import your OpenAudible CSV export to browse, search and sort your collection.'
+            : 'Load the CSV export configured on the server to browse your collection.'
+        }
+      >
+        <Button variant="primary" icon={FileUp} loading={loading} onClick={handleLoadCsv}>
+          {isElectron ? 'Load CSV export' : 'Load library'}
+        </Button>
+        {!isElectron && csvPath && (
+          <p className="max-w-sm break-all text-2xs text-fg-subtle">{csvPath}</p>
+        )}
+        {error && <Banner tone="critical">{error}</Banner>}
+        {notice && <Banner tone="caution">{notice}</Banner>}
+      </EmptyState>
     );
   }
 
-  const columns = [
-    { key: 'title', label: 'Title', width: 'flex-[2.5]' },
-    { key: 'author', label: 'Author', width: 'flex-[1.5]' },
-    { key: 'narratedBy', label: 'Narrator', width: 'flex-[1.5]' },
-    { key: 'seriesName', label: 'Series', width: 'flex-1' },
-    { key: 'duration', label: 'Duration', width: 'w-28' },
-    { key: 'aveRating', label: 'Rating', width: 'w-24' },
-  ];
-
   return (
-    <div className="flex-1 flex flex-col min-h-0">
-      {/* Header */}
-      <div className="flex items-center justify-between mb-5">
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h2 className="text-lg font-bold text-white">Library</h2>
-          <p className="text-xs text-slate-400 mt-0.5">
-            {filtered.length} of {books.length} audiobook{books.length !== 1 ? 's' : ''}
+          <h1 className="text-lg font-semibold text-fg">Library</h1>
+          <p className="tabular text-xs text-fg-muted">
+            {rows.length === books.length
+              ? `${books.length.toLocaleString()} audiobooks`
+              : `${rows.length.toLocaleString()} of ${books.length.toLocaleString()} audiobooks`}
           </p>
         </div>
-        <div className="flex items-center gap-3">
-          <div className="relative">
-            <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-            <input
-              type="text"
-              placeholder="Search books..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="input-field pl-9 w-64 !py-2 text-sm"
-            />
-          </div>
-          <button onClick={handleLoadCsv} disabled={loading} className="btn-secondary inline-flex items-center gap-2 text-sm !py-2">
-            <FileUp size={14} />
-            {loading ? 'Loading...' : isElectron ? 'Reload' : 'Reload Library'}
-          </button>
+
+        <div className="flex items-center gap-2">
+          <TextInput
+            type="search"
+            icon={Search}
+            className="w-56"
+            placeholder="Search"
+            aria-label="Search books"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+          />
+          <Button icon={FileUp} loading={loading} onClick={handleLoadCsv}>
+            Reload
+          </Button>
         </div>
       </div>
 
-      {error && (
-        <div className="mb-4 text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
-          {error}
-        </div>
-      )}
+      {error && <Banner tone="critical">{error}</Banner>}
+      {notice && <Banner tone="caution">{notice}</Banner>}
 
-      {notice && (
-        <div className="mb-4 text-sm text-amber-300 bg-amber-500/10 border border-amber-500/20 rounded-lg px-4 py-2">
-          {notice}
-        </div>
-      )}
-
-      {/* Table */}
-      <div className="glass-card flex-1 flex flex-col min-h-0 overflow-hidden">
-        {/* Table Header */}
-        <div className="flex items-center px-5 py-3 border-b border-slate-700/50 bg-slate-800/40 text-xs font-semibold text-slate-400 uppercase tracking-wider">
-          {columns.map((col) => (
-            <button
-              key={col.key}
-              onClick={() => handleSort(col.key)}
-              className={`group flex items-center gap-1.5 ${col.width} hover:text-slate-200 transition-colors`}
-            >
-              {col.label}
-              <SortIcon field={col.key} />
-            </button>
-          ))}
-        </div>
-
-        {/* Table Body */}
-        <div className="flex-1 overflow-y-auto">
-          {filtered.map((book, i) => (
-            <div
-              key={book.key || book.asin || i}
-              className="flex items-center px-5 py-3 border-b border-slate-700/20 hover:bg-slate-700/20 transition-colors group"
-            >
-              <div className="flex-[2.5] pr-3">
-                <p className="text-sm font-medium text-slate-100 truncate group-hover:text-white transition-colors">
-                  {book.title || 'Untitled'}
-                </p>
-                {book.shortTitle && book.shortTitle !== book.title && (
-                  <p className="text-[11px] text-slate-500 truncate">{book.shortTitle}</p>
-                )}
-              </div>
-              <div className="flex-[1.5] pr-3">
-                <div className="flex items-center gap-1.5">
-                  <User size={12} className="text-slate-500 shrink-0" />
-                  <span className="text-sm text-slate-300 truncate">{book.author || '—'}</span>
-                </div>
-              </div>
-              <div className="flex-[1.5] pr-3">
-                <span className="text-sm text-slate-400 truncate block">{book.narratedBy || '—'}</span>
-              </div>
-              <div className="flex-1 pr-3">
-                <span className="text-sm text-slate-400 truncate block">
-                  {book.seriesName
-                    ? `${book.seriesName}${book.seriesSequence ? ` #${book.seriesSequence}` : ''}`
-                    : '—'}
-                </span>
-              </div>
-              <div className="w-28">
-                <div className="flex items-center gap-1.5 text-sm text-slate-400">
-                  <Clock size={12} className="text-slate-500 shrink-0" />
-                  <span className="truncate">{book.duration || '—'}</span>
-                </div>
-              </div>
-              <div className="w-24">
-                {book.aveRating > 0 ? (
-                  <div className="flex items-center gap-1.5 text-sm">
-                    <Star size={12} className="text-amber-400 fill-amber-400 shrink-0" />
-                    <span className="text-slate-300">{book.aveRating.toFixed(1)}</span>
-                  </div>
-                ) : (
-                  <span className="text-sm text-slate-500">—</span>
-                )}
-              </div>
-            </div>
-          ))}
-
-          {filtered.length === 0 && books.length > 0 && (
-            <div className="text-center py-16 text-slate-500">
-              <Search size={32} className="mx-auto mb-3 opacity-40" />
-              <p className="text-sm">No books match your search</p>
-            </div>
-          )}
-        </div>
-      </div>
+      <LibraryTable
+        books={rows}
+        sortField={sort.field}
+        sortDir={sort.dir}
+        onSort={handleSort}
+        searchActive={debouncedSearch.trim().length > 0}
+      />
     </div>
   );
 }
+
+// Memoised so that polling a running sort — which updates state two and a half times a second in
+// the shell above — does not re-render the whole book table alongside it.
+export default memo(LibraryView);

--- a/electron-ui/src/components/Library.jsx
+++ b/electron-ui/src/components/Library.jsx
@@ -9,6 +9,15 @@ import LibraryTable from './LibraryTable';
 
 const SEARCH_FIELDS = ['title', 'author', 'seriesName', 'narratedBy'];
 
+const SORT_LABELS = {
+  title: 'title',
+  author: 'author',
+  seriesName: 'series',
+  narratedBy: 'narrator',
+  duration: 'duration',
+  aveRating: 'rating',
+};
+
 // Natural ordering, so "Book 2" sorts before "Book 10" and accented names file where a reader
 // expects. Built once rather than per comparison: constructing a collator is not cheap, and doing
 // it inside the sort callback made large libraries noticeably slow to reorder.
@@ -62,6 +71,12 @@ function LibraryView({ books, setBooks, csvPath }) {
     setSort((prev) => (prev.field === field ? { field, dir: prev.dir === 'asc' ? 'desc' : 'asc' } : { field, dir: 'asc' }));
   }, []);
 
+  // The window got too narrow for the column being sorted on. Fall back to Title, which is never
+  // dropped, so the order on screen always corresponds to a header the user can see and change.
+  const handleSortFieldHidden = useCallback(() => {
+    setSort({ field: 'title', dir: 'asc' });
+  }, []);
+
   // Filtering and sorting are separate passes so that typing does not pay for a re-sort and
   // re-sorting does not pay for a re-filter.
   const filtered = useMemo(() => {
@@ -96,6 +111,16 @@ function LibraryView({ books, setBooks, csvPath }) {
 
     return sorted;
   }, [filtered, sort]);
+
+  const sortLabel = SORT_LABELS[sort.field] ?? sort.field;
+  const announcement = [
+    debouncedSearch.trim()
+      ? rows.length === 0
+        ? `No books match ${debouncedSearch.trim()}`
+        : `${rows.length.toLocaleString()} of ${books.length.toLocaleString()} books match ${debouncedSearch.trim()}`
+      : `${books.length.toLocaleString()} books`,
+    `sorted by ${sortLabel}, ${sort.dir === 'asc' ? 'ascending' : 'descending'}`,
+  ].join(', ');
 
   if (books.length === 0) {
     return (
@@ -151,12 +176,23 @@ function LibraryView({ books, setBooks, csvPath }) {
       {error && <Banner tone="critical">{error}</Banner>}
       {notice && <Banner tone="caution">{notice}</Banner>}
 
+      {/*
+        Always mounted, so it actually announces. A live region that appears at the same moment as
+        its text is frequently missed: assistive tech has to be observing the node before the text
+        lands in it.
+      */}
+      <p aria-live="polite" className="sr-only">
+        {announcement}
+      </p>
+
       <LibraryTable
         books={rows}
         sortField={sort.field}
         sortDir={sort.dir}
         onSort={handleSort}
+        onSortFieldHidden={handleSortFieldHidden}
         searchActive={debouncedSearch.trim().length > 0}
+        resetKey={`${debouncedSearch}\u0000${sort.field}\u0000${sort.dir}`}
       />
     </div>
   );

--- a/electron-ui/src/components/Library.jsx
+++ b/electron-ui/src/components/Library.jsx
@@ -17,6 +17,7 @@ export default function LibraryView({ books, setBooks, sortState }) {
   const [sortDir, setSortDir] = useState('asc');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [notice, setNotice] = useState(null);
   const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
 
   const handleLoadCsv = async () => {
@@ -34,9 +35,19 @@ export default function LibraryView({ books, setBooks, sortState }) {
 
     setLoading(true);
     setError(null);
+    setNotice(null);
     try {
-      const data = await parseBooks(filePath);
-      setBooks(data);
+      const { books: loaded, skippedRows } = await parseBooks(filePath);
+      setBooks(loaded);
+
+      if (skippedRows > 0) {
+        setNotice(
+          `${skippedRows} row${skippedRows === 1 ? '' : 's'} could not be read and were skipped. ` +
+            `${loaded.length} book${loaded.length === 1 ? '' : 's'} loaded.`
+        );
+      } else if (loaded.length === 0) {
+        setNotice('The export was read successfully but contained no books.');
+      }
     } catch (err) {
       setError(err.message);
     } finally {
@@ -114,6 +125,11 @@ export default function LibraryView({ books, setBooks, sortState }) {
               {error}
             </p>
           )}
+          {notice && (
+            <p className="mt-4 text-sm text-amber-300 bg-amber-500/10 border border-amber-500/20 rounded-lg px-4 py-2">
+              {notice}
+            </p>
+          )}
         </div>
       </div>
     );
@@ -159,6 +175,12 @@ export default function LibraryView({ books, setBooks, sortState }) {
       {error && (
         <div className="mb-4 text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-2">
           {error}
+        </div>
+      )}
+
+      {notice && (
+        <div className="mb-4 text-sm text-amber-300 bg-amber-500/10 border border-amber-500/20 rounded-lg px-4 py-2">
+          {notice}
         </div>
       )}
 

--- a/electron-ui/src/components/Library.jsx
+++ b/electron-ui/src/components/Library.jsx
@@ -2,26 +2,11 @@ import { memo, useCallback, useMemo, useState } from 'react';
 import { BookOpen, FileUp, Search } from 'lucide-react';
 import { parseBooks } from '../api';
 import { useDebounced, useIsElectron } from '../hooks';
+import { compareBooks, filterBooks, SORT_LABELS } from '../sorting';
 import Button from './ui/Button';
 import { TextInput } from './ui/Field';
 import { Banner, EmptyState } from './ui/Surface';
 import LibraryTable from './LibraryTable';
-
-const SEARCH_FIELDS = ['title', 'author', 'seriesName', 'narratedBy'];
-
-const SORT_LABELS = {
-  title: 'title',
-  author: 'author',
-  seriesName: 'series',
-  narratedBy: 'narrator',
-  duration: 'duration',
-  aveRating: 'rating',
-};
-
-// Natural ordering, so "Book 2" sorts before "Book 10" and accented names file where a reader
-// expects. Built once rather than per comparison: constructing a collator is not cheap, and doing
-// it inside the sort callback made large libraries noticeably slow to reorder.
-const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 
 function LibraryView({ books, setBooks, csvPath }) {
   const isElectron = useIsElectron();
@@ -79,38 +64,12 @@ function LibraryView({ books, setBooks, csvPath }) {
 
   // Filtering and sorting are separate passes so that typing does not pay for a re-sort and
   // re-sorting does not pay for a re-filter.
-  const filtered = useMemo(() => {
-    const query = debouncedSearch.trim().toLowerCase();
-    if (!query) return books;
+  const filtered = useMemo(() => filterBooks(books, debouncedSearch), [books, debouncedSearch]);
 
-    return books.filter((book) =>
-      SEARCH_FIELDS.some((field) => book[field]?.toLowerCase().includes(query))
-    );
-  }, [books, debouncedSearch]);
-
-  const rows = useMemo(() => {
-    const { field, dir } = sort;
-    const sorted = [...filtered];
-
-    sorted.sort((a, b) => {
-      const left = a[field];
-      const right = b[field];
-
-      // Books missing the sorted-on value collect at the end either way, rather than forming a
-      // block of blanks at the top when the direction flips.
-      if (left == null || left === '') return right == null || right === '' ? 0 : 1;
-      if (right == null || right === '') return -1;
-
-      const comparison =
-        typeof left === 'number' && typeof right === 'number'
-          ? left - right
-          : collator.compare(String(left), String(right));
-
-      return dir === 'asc' ? comparison : -comparison;
-    });
-
-    return sorted;
-  }, [filtered, sort]);
+  const rows = useMemo(
+    () => [...filtered].sort(compareBooks(sort.field, sort.dir)),
+    [filtered, sort]
+  );
 
   const sortLabel = SORT_LABELS[sort.field] ?? sort.field;
   const announcement = [

--- a/electron-ui/src/components/LibraryTable.jsx
+++ b/electron-ui/src/components/LibraryTable.jsx
@@ -1,0 +1,163 @@
+import { memo } from 'react';
+import { ArrowDown, ArrowUp, Search } from 'lucide-react';
+import { useElementWidth, useVirtualRows } from '../hooks';
+import { formatDuration } from '../format';
+
+const ROW_HEIGHT = 40;
+
+/**
+ * Column definitions, in priority order. `minTableWidth` is the width below which the column is
+ * dropped, so a narrow window sheds detail instead of crushing every column into ellipses.
+ */
+const COLUMNS = [
+  { key: 'title', label: 'Title', width: '2.4fr', minTableWidth: 0 },
+  { key: 'author', label: 'Author', width: '1.5fr', minTableWidth: 0 },
+  { key: 'seriesName', label: 'Series', width: '1.4fr', minTableWidth: 720 },
+  { key: 'narratedBy', label: 'Narrator', width: '1.4fr', minTableWidth: 940 },
+  { key: 'duration', label: 'Duration', width: '92px', minTableWidth: 560, align: 'right' },
+  { key: 'aveRating', label: 'Rating', width: '80px', minTableWidth: 1120, align: 'right' },
+];
+
+function cellValue(book, key) {
+  if (key === 'seriesName') {
+    if (!book.seriesName) return '—';
+    return book.seriesSequence ? `${book.seriesName} #${book.seriesSequence}` : book.seriesName;
+  }
+
+  if (key === 'duration') {
+    return formatDuration(book.duration);
+  }
+
+  if (key === 'aveRating') {
+    return book.aveRating > 0 ? book.aveRating.toFixed(1) : '—';
+  }
+
+  return book[key] || '—';
+}
+
+/** The unabbreviated value, for the cell tooltip. */
+function cellTitle(book, key) {
+  if (key === 'duration') return book.duration || undefined;
+  return undefined;
+}
+
+const Row = memo(function Row({ book, columns }) {
+  return (
+    <tr className="border-b border-line/60 hover:bg-raised/50">
+      {columns.map((column) => {
+        const value = cellValue(book, column.key);
+        const isTitle = column.key === 'title';
+
+        return (
+          <td
+            key={column.key}
+            title={cellTitle(book, column.key) ?? (value !== '—' ? value : undefined)}
+            className={[
+              'truncate px-4',
+              column.align === 'right' ? 'text-right tabular' : '',
+              isTitle ? 'font-medium text-fg' : 'text-fg-muted',
+            ].join(' ')}
+            style={{ height: ROW_HEIGHT }}
+          >
+            {value}
+          </td>
+        );
+      })}
+    </tr>
+  );
+});
+
+function SortIndicator({ active, direction }) {
+  if (!active) return <span className="inline-block w-3.5" aria-hidden="true" />;
+  const Icon = direction === 'asc' ? ArrowUp : ArrowDown;
+  return <Icon size={13} className="shrink-0 text-accent" aria-hidden="true" />;
+}
+
+/**
+ * The book list.
+ *
+ * A real <table> with <colgroup>: the column widths are declared once and shared by the header and
+ * every row, so the two can no longer drift apart the way parallel flex widths did. Only the rows
+ * near the viewport are rendered — see useVirtualRows — with spacer rows standing in for the rest,
+ * which keeps a ten thousand book library scrolling at full speed.
+ */
+export default function LibraryTable({ books, sortField, sortDir, onSort, searchActive }) {
+  const [containerRef, containerWidth] = useElementWidth();
+  const columns = COLUMNS.filter((column) => containerWidth >= column.minTableWidth);
+
+  const { scrollRef, start, end, paddingTop, paddingBottom } = useVirtualRows({
+    count: books.length,
+    rowHeight: ROW_HEIGHT,
+  });
+
+  const visible = books.slice(start, end);
+
+  return (
+    <div ref={containerRef} className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-line bg-surface">
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
+        <table className="w-full table-fixed border-collapse text-sm">
+          <colgroup>
+            {columns.map((column) => (
+              <col key={column.key} style={{ width: column.width }} />
+            ))}
+          </colgroup>
+
+          <thead className="sticky top-0 z-10">
+            <tr>
+              {columns.map((column) => {
+                const active = sortField === column.key;
+
+                return (
+                  <th
+                    key={column.key}
+                    scope="col"
+                    aria-sort={active ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                    className="border-b border-line bg-surface p-0 text-left font-medium"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => onSort(column.key)}
+                      className={[
+                        'flex h-10 w-full items-center gap-1.5 px-4 text-xs transition-colors',
+                        column.align === 'right' ? 'justify-end' : '',
+                        active ? 'text-fg' : 'text-fg-muted hover:text-fg',
+                      ].join(' ')}
+                    >
+                      {column.label}
+                      <SortIndicator active={active} direction={sortDir} />
+                    </button>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+
+          <tbody>
+            {paddingTop > 0 && (
+              <tr aria-hidden="true">
+                <td colSpan={columns.length} style={{ height: paddingTop }} />
+              </tr>
+            )}
+
+            {visible.map((book, index) => (
+              <Row key={book.key || book.asin || start + index} book={book} columns={columns} />
+            ))}
+
+            {paddingBottom > 0 && (
+              <tr aria-hidden="true">
+                <td colSpan={columns.length} style={{ height: paddingBottom }} />
+              </tr>
+            )}
+          </tbody>
+        </table>
+
+        {books.length === 0 && searchActive && (
+          <div className="flex flex-col items-center py-16 text-fg-subtle">
+            <Search size={22} className="mb-3" aria-hidden="true" />
+            <p className="text-sm">No books match your search</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/electron-ui/src/components/LibraryTable.jsx
+++ b/electron-ui/src/components/LibraryTable.jsx
@@ -125,11 +125,13 @@ export default function LibraryTable({
   }, [resetKey, scrollToTop]);
 
   // Sorting by a column that is no longer rendered leaves the order unexplained and unchangeable.
+  // Guarded on a measured width: before the first measurement every optional column looks absent,
+  // and acting on that would silently discard the sort each time the view mounts.
   useEffect(() => {
-    if (!columns.some((column) => column.key === sortField)) {
+    if (containerWidth > 0 && !columns.some((column) => column.key === sortField)) {
       onSortFieldHidden?.();
     }
-  }, [columns, sortField, onSortFieldHidden]);
+  }, [containerWidth, columns, sortField, onSortFieldHidden]);
 
   const visible = books.slice(start, end);
 

--- a/electron-ui/src/components/LibraryTable.jsx
+++ b/electron-ui/src/components/LibraryTable.jsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import { ArrowDown, ArrowUp, Search } from 'lucide-react';
 import { useElementWidth, useVirtualRows } from '../hooks';
 import { formatDuration } from '../format';
@@ -7,7 +7,9 @@ const ROW_HEIGHT = 40;
 
 /**
  * Column definitions, in priority order. `minTableWidth` is the width below which the column is
- * dropped, so a narrow window sheds detail instead of crushing every column into ellipses.
+ * dropped, so a narrow window sheds detail instead of crushing every column into ellipses. Title
+ * and Author have no threshold: they are the floor, and below the width that fits them the table
+ * scrolls sideways rather than shedding anything further.
  */
 const COLUMNS = [
   { key: 'title', label: 'Title', width: '2.4fr', minTableWidth: 0 },
@@ -17,6 +19,8 @@ const COLUMNS = [
   { key: 'duration', label: 'Duration', width: '92px', minTableWidth: 560, align: 'right' },
   { key: 'aveRating', label: 'Rating', width: '80px', minTableWidth: 1120, align: 'right' },
 ];
+
+const MIN_TABLE_WIDTH = 420;
 
 function cellValue(book, key) {
   if (key === 'seriesName') {
@@ -41,9 +45,9 @@ function cellTitle(book, key) {
   return undefined;
 }
 
-const Row = memo(function Row({ book, columns }) {
+const Row = memo(function Row({ book, columns, rowIndex }) {
   return (
-    <tr className="border-b border-line/60 hover:bg-raised/50">
+    <tr aria-rowindex={rowIndex} className="border-b border-line/60 hover:bg-raised/50">
       {columns.map((column) => {
         const value = cellValue(book, column.key);
         const isTitle = column.key === 'title';
@@ -54,7 +58,7 @@ const Row = memo(function Row({ book, columns }) {
             title={cellTitle(book, column.key) ?? (value !== '—' ? value : undefined)}
             className={[
               'truncate px-4',
-              column.align === 'right' ? 'text-right tabular' : '',
+              column.align === 'right' ? 'tabular text-right' : '',
               isTitle ? 'font-medium text-fg' : 'text-fg-muted',
             ].join(' ')}
             style={{ height: ROW_HEIGHT }}
@@ -80,22 +84,67 @@ function SortIndicator({ active, direction }) {
  * every row, so the two can no longer drift apart the way parallel flex widths did. Only the rows
  * near the viewport are rendered — see useVirtualRows — with spacer rows standing in for the rest,
  * which keeps a ten thousand book library scrolling at full speed.
+ *
+ * Because the DOM no longer holds a row per book, the row geometry has to be restated on the ARIA
+ * layer: aria-rowcount on the table and aria-rowindex on each row, or assistive tech reports the
+ * size of the window instead of the size of the library.
  */
-export default function LibraryTable({ books, sortField, sortDir, onSort, searchActive }) {
+export default function LibraryTable({
+  books,
+  sortField,
+  sortDir,
+  onSort,
+  onSortFieldHidden,
+  searchActive,
+  resetKey,
+}) {
   const [containerRef, containerWidth] = useElementWidth();
-  const columns = COLUMNS.filter((column) => containerWidth >= column.minTableWidth);
 
-  const { scrollRef, start, end, paddingTop, paddingBottom } = useVirtualRows({
+  // Keyed on the set of visible columns rather than the raw width: a new array on every pixel of
+  // resize — or worse, on every render — would defeat the memo on Row and reconcile every visible
+  // row on every scroll frame.
+  const visibleKeys = COLUMNS.filter((column) => containerWidth >= column.minTableWidth)
+    .map((column) => column.key)
+    .join(',');
+
+  const columns = useMemo(
+    () => COLUMNS.filter((column) => visibleKeys.split(',').includes(column.key)),
+    [visibleKeys]
+  );
+
+  const { scrollRef, start, end, paddingTop, paddingBottom, scrollToTop } = useVirtualRows({
     count: books.length,
     rowHeight: ROW_HEIGHT,
   });
 
+  // A new result set starts at the top. Without this, searching from halfway down leaves scrollTop
+  // pointing past the end of a much shorter list: the window resolves to an empty slice and the
+  // user is shown a blank table that then judders upwards.
+  useEffect(() => {
+    scrollToTop();
+  }, [resetKey, scrollToTop]);
+
+  // Sorting by a column that is no longer rendered leaves the order unexplained and unchangeable.
+  useEffect(() => {
+    if (!columns.some((column) => column.key === sortField)) {
+      onSortFieldHidden?.();
+    }
+  }, [columns, sortField, onSortFieldHidden]);
+
   const visible = books.slice(start, end);
 
   return (
-    <div ref={containerRef} className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-line bg-surface">
+    <div
+      ref={containerRef}
+      className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-line bg-surface"
+    >
       <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto">
-        <table className="w-full table-fixed border-collapse text-sm">
+        <table
+          aria-label="Audiobooks"
+          aria-rowcount={books.length + 1}
+          className="w-full table-fixed border-collapse text-sm"
+          style={{ minWidth: MIN_TABLE_WIDTH }}
+        >
           <colgroup>
             {columns.map((column) => (
               <col key={column.key} style={{ width: column.width }} />
@@ -103,9 +152,10 @@ export default function LibraryTable({ books, sortField, sortDir, onSort, search
           </colgroup>
 
           <thead className="sticky top-0 z-10">
-            <tr>
+            <tr aria-rowindex={1}>
               {columns.map((column) => {
                 const active = sortField === column.key;
+                const nextDirection = active && sortDir === 'asc' ? 'descending' : 'ascending';
 
                 return (
                   <th
@@ -117,13 +167,16 @@ export default function LibraryTable({ books, sortField, sortDir, onSort, search
                     <button
                       type="button"
                       onClick={() => onSort(column.key)}
+                      // The visible label alone would leave a keyboard user with no idea what
+                      // pressing it does, since the direction arrow is decorative.
+                      aria-label={`${column.label}, sort ${nextDirection}`}
                       className={[
                         'flex h-10 w-full items-center gap-1.5 px-4 text-xs transition-colors',
                         column.align === 'right' ? 'justify-end' : '',
                         active ? 'text-fg' : 'text-fg-muted hover:text-fg',
                       ].join(' ')}
                     >
-                      {column.label}
+                      <span aria-hidden="true">{column.label}</span>
                       <SortIndicator active={active} direction={sortDir} />
                     </button>
                   </th>
@@ -133,18 +186,25 @@ export default function LibraryTable({ books, sortField, sortDir, onSort, search
           </thead>
 
           <tbody>
+            {/* role="presentation" so the spacers do not count themselves as rows. */}
             {paddingTop > 0 && (
-              <tr aria-hidden="true">
+              <tr role="presentation">
                 <td colSpan={columns.length} style={{ height: paddingTop }} />
               </tr>
             )}
 
             {visible.map((book, index) => (
-              <Row key={book.key || book.asin || start + index} book={book} columns={columns} />
+              <Row
+                key={book.key || book.asin || start + index}
+                book={book}
+                columns={columns}
+                // +2: ARIA row indices are 1-based and the header occupies row 1.
+                rowIndex={start + index + 2}
+              />
             ))}
 
             {paddingBottom > 0 && (
-              <tr aria-hidden="true">
+              <tr role="presentation">
                 <td colSpan={columns.length} style={{ height: paddingBottom }} />
               </tr>
             )}

--- a/electron-ui/src/components/Sidebar.jsx
+++ b/electron-ui/src/components/Sidebar.jsx
@@ -1,60 +1,57 @@
 import { Library, ArrowUpDown, Headphones } from 'lucide-react';
 
-const navItems = [
+const NAV_ITEMS = [
   { id: 'library', label: 'Library', icon: Library },
-  { id: 'sort', label: 'Sort Files', icon: ArrowUpDown },
+  { id: 'sort', label: 'Sort', icon: ArrowUpDown },
 ];
 
+/**
+ * Primary navigation. Collapses to an icon rail on a narrow window rather than holding a fixed
+ * 240px, which on a small laptop was taking a fifth of the width to show two words.
+ */
 export default function Sidebar({ currentPage, onPageChange, bookCount }) {
   return (
-    <aside className="w-60 bg-slate-800/40 border-r border-slate-700/40 flex flex-col shrink-0">
-      {/* Branding */}
-      <div className="p-5 pb-6">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-xl bg-gradient-to-br from-brand-500 via-brand-600 to-violet-600 flex items-center justify-center shadow-lg shadow-brand-500/25">
-            <Headphones size={20} className="text-white" />
-          </div>
-          <div>
-            <h1 className="text-sm font-bold text-white leading-tight">OpenAudible</h1>
-            <p className="text-[11px] text-slate-400 leading-tight">Book Organizer</p>
-          </div>
-        </div>
+    <nav
+      aria-label="Main"
+      className="flex w-14 shrink-0 flex-col border-r border-line bg-canvas lg:w-52"
+    >
+      <div className="flex h-14 items-center gap-2.5 px-4">
+        <Headphones size={18} className="shrink-0 text-fg-muted" aria-hidden="true" />
+        <span className="hidden truncate text-sm font-semibold text-fg lg:block">Organizer</span>
       </div>
 
-      {/* Navigation */}
-      <nav className="flex-1 px-3 space-y-1">
-        <p className="px-3 mb-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500">
-          Menu
-        </p>
-        {navItems.map((item) => {
-          const Icon = item.icon;
-          const isActive = currentPage === item.id;
+      <ul className="flex-1 space-y-0.5 px-2">
+        {NAV_ITEMS.map(({ id, label, icon: Icon }) => {
+          const isActive = currentPage === id;
+
           return (
-            <button
-              key={item.id}
-              onClick={() => onPageChange(item.id)}
-              className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 ${
-                isActive
-                  ? 'bg-brand-500/15 text-brand-400 shadow-sm'
-                  : 'text-slate-400 hover:bg-slate-700/40 hover:text-slate-200'
-              }`}
-            >
-              <Icon size={18} strokeWidth={isActive ? 2.2 : 1.8} />
-              <span>{item.label}</span>
-            </button>
+            <li key={id}>
+              <button
+                type="button"
+                onClick={() => onPageChange(id)}
+                aria-current={isActive ? 'page' : undefined}
+                title={label}
+                className={[
+                  'flex h-9 w-full items-center gap-2.5 rounded px-3 text-sm transition-colors',
+                  isActive
+                    ? 'bg-raised font-medium text-fg'
+                    : 'text-fg-muted hover:bg-raised/60 hover:text-fg',
+                ].join(' ')}
+              >
+                <Icon size={16} className="shrink-0" aria-hidden="true" />
+                <span className="hidden lg:block">{label}</span>
+              </button>
+            </li>
           );
         })}
-      </nav>
+      </ul>
 
-      {/* Footer stats */}
-      <div className="p-4 mx-3 mb-3 rounded-xl bg-slate-800/80 border border-slate-700/40">
-        <div className="flex items-center justify-between">
-          <span className="text-xs text-slate-500">Books loaded</span>
-          <span className="text-xs font-bold text-brand-400">
-            {bookCount > 0 ? bookCount.toLocaleString() : '—'}
-          </span>
-        </div>
+      <div className="hidden border-t border-line px-5 py-3 lg:block">
+        <p className="text-2xs text-fg-subtle">Books loaded</p>
+        <p className="tabular text-sm font-medium text-fg">
+          {bookCount > 0 ? bookCount.toLocaleString() : '—'}
+        </p>
       </div>
-    </aside>
+    </nav>
   );
 }

--- a/electron-ui/src/components/Sidebar.jsx
+++ b/electron-ui/src/components/Sidebar.jsx
@@ -13,11 +13,11 @@ export default function Sidebar({ currentPage, onPageChange, bookCount }) {
   return (
     <nav
       aria-label="Main"
-      className="flex w-14 shrink-0 flex-col border-r border-line bg-canvas lg:w-52"
+      className="flex w-14 shrink-0 flex-col border-r border-line bg-canvas xl:w-52"
     >
       <div className="flex h-14 items-center gap-2.5 px-4">
         <Headphones size={18} className="shrink-0 text-fg-muted" aria-hidden="true" />
-        <span className="hidden truncate text-sm font-semibold text-fg lg:block">Organizer</span>
+        <span className="hidden truncate text-sm font-semibold text-fg xl:block">Organizer</span>
       </div>
 
       <ul className="flex-1 space-y-0.5 px-2">
@@ -39,14 +39,14 @@ export default function Sidebar({ currentPage, onPageChange, bookCount }) {
                 ].join(' ')}
               >
                 <Icon size={16} className="shrink-0" aria-hidden="true" />
-                <span className="hidden lg:block">{label}</span>
+                <span className="hidden xl:block">{label}</span>
               </button>
             </li>
           );
         })}
       </ul>
 
-      <div className="hidden border-t border-line px-5 py-3 lg:block">
+      <div className="hidden border-t border-line px-5 py-3 xl:block">
         <p className="text-2xs text-fg-subtle">Books loaded</p>
         <p className="tabular text-sm font-medium text-fg">
           {bookCount > 0 ? bookCount.toLocaleString() : '—'}

--- a/electron-ui/src/components/SortPanel.jsx
+++ b/electron-ui/src/components/SortPanel.jsx
@@ -1,475 +1,231 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { memo } from 'react';
 import {
-  FolderOpen,
   FileSpreadsheet,
+  FolderOpen,
   FolderOutput,
-  Play,
-  Square,
-  CheckCircle2,
-  AlertCircle,
-  Loader2,
-  ArrowUpDown,
   Gauge,
+  Play,
   ShieldCheck,
+  Square,
 } from 'lucide-react';
-import { startSort, getSortProgress, cancelSort } from '../api';
-
-const POLL_INTERVAL_MS = 400;
-const MAX_POLL_FAILURES = 25; // ~10 seconds of silence before giving up
+import { useIsElectron, useSortRun } from '../hooks';
+import Button from './ui/Button';
+import { Field, PathInput } from './ui/Field';
+import SegmentedControl from './ui/SegmentedControl';
+import { Banner, Card, ProgressBar, Stat } from './ui/Surface';
 
 const COMPARISON_MODES = [
   {
     value: 'quick',
     label: 'Quick',
-    description:
-      'Replaces a book when its size or sampled contents differ. Fast, and catches almost every re-release.',
+    icon: Gauge,
+    description: 'Replaces a book when its size or sampled contents differ. Fast enough to run every time.',
   },
   {
     value: 'full',
     label: 'Verify contents',
-    description:
-      'Compares every byte and replaces any book that changed. Slower, but never leaves a stale copy behind.',
+    icon: ShieldCheck,
+    description: 'Compares every byte, so a re-release of identical size is still caught. Slower.',
   },
 ];
 
-export default function SortPanel({ books, sortState, setSortState }) {
-  const { csvPath, sourcePath, destPath, sorting, progress, error } = sortState;
-  const comparisonMode = sortState.comparisonMode === 'full' ? 'full' : 'quick';
-  const pollRef = useRef(null);
-  const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
+const PATHS = [
+  { key: 'csvPath', label: 'OpenAudible CSV export', icon: FileSpreadsheet, picker: 'file' },
+  { key: 'sourcePath', label: 'Source folder', icon: FolderOpen, picker: 'folder' },
+  { key: 'destPath', label: 'Destination folder', icon: FolderOutput, picker: 'folder' },
+];
 
-  const update = useCallback((patch) => {
-    setSortState((prev) => ({ ...prev, ...patch }));
-  }, [setSortState]);
+function SortPanel({ config, setConfig, run, setRun }) {
+  const isElectron = useIsElectron();
+  const { start, cancel } = useSortRun({ run, setRun, config });
 
-  const handleBrowseCsv = async () => {
-    const path = await window.electronAPI?.openFile([
-      { name: 'CSV Files', extensions: ['csv'] },
-    ]);
-    if (path) update({ csvPath: path });
+  const { sorting, progress, error } = run;
+  const comparisonMode = config.comparisonMode === 'full' ? 'full' : 'quick';
+  const selectedMode = COMPARISON_MODES.find((mode) => mode.value === comparisonMode);
+
+  const browse = async (key, picker) => {
+    const path =
+      picker === 'file'
+        ? await window.electronAPI?.openFile([{ name: 'CSV Files', extensions: ['csv'] }])
+        : await window.electronAPI?.openFolder();
+
+    if (path) setConfig((prev) => ({ ...prev, [key]: path }));
   };
 
-  const handleBrowseSource = async () => {
-    const path = await window.electronAPI?.openFolder();
-    if (path) update({ sourcePath: path });
-  };
-
-  const handleBrowseDest = async () => {
-    const path = await window.electronAPI?.openFolder();
-    if (path) update({ destPath: path });
-  };
-
-  const handleStartSort = async () => {
-    if (!csvPath || !sourcePath || !destPath) {
-      update({ error: 'All three paths are required' });
-      return;
-    }
-
-    update({ error: null, sorting: true, progress: null });
-
-    try {
-      await startSort(csvPath, sourcePath, destPath, comparisonMode);
-      startPolling();
-    } catch (err) {
-      update({ error: err.message, sorting: false });
-    }
-  };
-
-  const handleCancelSort = async () => {
-    try {
-      await cancelSort();
-      update({ error: null });
-    } catch (err) {
-      update({ error: err.message });
-    }
-  };
-
-  const startPolling = useCallback(() => {
-    if (pollRef.current) clearInterval(pollRef.current);
-
-    // A transient failure is normal; a run of them means the backend is gone, and spinning
-    // "Sorting..." forever is worse than saying so.
-    let consecutiveFailures = 0;
-
-    const stop = () => {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    };
-
-    pollRef.current = setInterval(async () => {
-      try {
-        const p = await getSortProgress();
-        consecutiveFailures = 0;
-
-        const patches = { progress: p };
-        if (p.isComplete) {
-          stop();
-          patches.sorting = false;
-          if (p.error) patches.error = p.error;
-        }
-        setSortState((prev) => ({ ...prev, ...patches }));
-      } catch (err) {
-        consecutiveFailures += 1;
-        if (consecutiveFailures >= MAX_POLL_FAILURES) {
-          stop();
-          setSortState((prev) => ({
-            ...prev,
-            sorting: false,
-            error: `Lost contact with the backend while sorting: ${err.message}`,
-          }));
-        }
-      }
-    }, POLL_INTERVAL_MS);
-  }, [setSortState]);
-
-  // Resume polling when component remounts while a sort is still active
-  useEffect(() => {
-    if (sorting && !pollRef.current) {
-      startPolling();
-    }
-    return () => {
-      if (pollRef.current) {
-        clearInterval(pollRef.current);
-        pollRef.current = null;
-      }
-    };
-  }, [sorting, startPolling]);
-
-  const isCanceled = progress?.isCanceled;
-  const isComplete = progress?.isComplete && !progress?.error && !isCanceled;
-  const hasError = progress?.error;
-  const progressDetails = parseProgressDetails(progress?.currentTitle);
-  const warningCount = progress?.warningCount || 0;
-
-  const updatedCount = progress?.updatedBooks || 0;
-
-  // skippedBooks was added alongside failedBooks; fall back for an older backend.
-  const skippedCount =
-    progress?.skippedBooks ??
-    Math.max(0, (progress?.currentBook || 0) - (progress?.copiedBooks || 0));
+  const ready = config.csvPath && config.sourcePath && config.destPath;
 
   return (
-    <div className="flex-1 flex flex-col min-h-0 overflow-y-auto">
-      <div className="mb-6">
-        <h2 className="text-lg font-bold text-white">Sort Audiobooks</h2>
-        <p className="text-xs text-slate-400 mt-0.5">
-          Organize your audiobook files into Author / Series / Book folder structure
-        </p>
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div>
+        <h1 className="text-lg font-semibold text-fg">Sort</h1>
+        <p className="text-xs text-fg-muted">Organize your files into Author / Series / Book folders</p>
       </div>
 
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
-        {/* Configuration Card */}
-        <div className="glass-card p-6">
-          <h3 className="text-sm font-semibold text-slate-200 mb-5">Configuration</h3>
-
+      <div className="grid min-h-0 flex-1 auto-rows-min grid-cols-1 items-start gap-4 overflow-y-auto xl:grid-cols-2">
+        <Card title="Configuration">
           <div className="space-y-4">
-            {/* CSV File */}
-            <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">
-                OpenAudible CSV Export
-              </label>
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <FileSpreadsheet size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-                  <input
-                    type="text"
-                    value={csvPath}
-                    placeholder={isElectron ? "Select CSV export file..." : "Configured by the server"}
-                    className="input-field pl-9 text-sm"
-                    readOnly
-                  />
-                </div>
-                {isElectron && (
-                  <button onClick={handleBrowseCsv} className="btn-secondary text-sm whitespace-nowrap">
-                    Browse
-                  </button>
-                )}
-              </div>
-            </div>
-
-            {/* Source Folder */}
-            <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">
-                Source Audio Folder
-              </label>
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <FolderOpen size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-                  <input
-                    type="text"
-                    value={sourcePath}
-                    placeholder={isElectron ? "Select source audio folder..." : "Configured by the server"}
-                    className="input-field pl-9 text-sm"
-                    readOnly
-                  />
-                </div>
-                {isElectron && (
-                  <button onClick={handleBrowseSource} className="btn-secondary text-sm whitespace-nowrap">
-                    Browse
-                  </button>
-                )}
-              </div>
-            </div>
-
-            {/* Destination Folder */}
-            <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">
-                Destination Folder
-              </label>
-              <div className="flex gap-2">
-                <div className="relative flex-1">
-                  <FolderOutput size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" />
-                  <input
-                    type="text"
-                    value={destPath}
-                    placeholder={isElectron ? "Select destination folder..." : "Configured by the server"}
-                    className="input-field pl-9 text-sm"
-                    readOnly
-                  />
-                </div>
-                {isElectron && (
-                  <button onClick={handleBrowseDest} className="btn-secondary text-sm whitespace-nowrap">
-                    Browse
-                  </button>
-                )}
-              </div>
-            </div>
-
-            {/* Update check */}
-            <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">
-                Update check
-              </label>
-              <div
-                role="radiogroup"
-                aria-label="Update check"
-                className="flex gap-1 p-1 bg-slate-800/80 border border-slate-600/50 rounded-lg"
-              >
-                {COMPARISON_MODES.map((mode) => (
-                  <button
-                    key={mode.value}
-                    type="button"
-                    role="radio"
-                    aria-checked={comparisonMode === mode.value}
-                    disabled={sorting}
-                    onClick={() => update({ comparisonMode: mode.value })}
-                    className={`flex-1 inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
-                      comparisonMode === mode.value
-                        ? 'bg-brand-600 text-white'
-                        : 'text-slate-300 hover:bg-slate-700/60'
-                    }`}
-                  >
-                    {mode.value === 'full' ? <ShieldCheck size={14} /> : <Gauge size={14} />}
-                    {mode.label}
-                  </button>
-                ))}
-              </div>
-              <p className="text-[11px] text-slate-500 mt-1.5">
-                {COMPARISON_MODES.find((mode) => mode.value === comparisonMode)?.description}
-              </p>
-            </div>
-          </div>
-
-          {error && (
-            <div className="mt-4 flex items-start gap-2 text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-3">
-              <AlertCircle size={16} className="shrink-0 mt-0.5" />
-              <span>{error}</span>
-            </div>
-          )}
-
-          <div className="mt-6 flex gap-3">
-            <button
-              onClick={handleStartSort}
-              disabled={sorting || !csvPath || !sourcePath || !destPath}
-              className="btn-primary flex-1 inline-flex items-center justify-center gap-2"
-            >
-              {sorting ? (
-                <>
-                  <Loader2 size={16} className="animate-spin" />
-                  Sorting...
-                </>
-              ) : (
-                <>
-                  <Play size={16} />
-                  Start Sorting
-                </>
-              )}
-            </button>
-
-            {sorting && (
-              <button
-                onClick={handleCancelSort}
-                className="btn-secondary inline-flex items-center justify-center gap-2 px-4"
-              >
-                <Square size={16} />
-                Cancel
-              </button>
-            )}
-          </div>
-        </div>
-
-        {/* Progress Card */}
-        <div className="glass-card p-6">
-          <h3 className="text-sm font-semibold text-slate-200 mb-5">Progress</h3>
-
-          {!progress && !sorting && (
-            <div className="flex flex-col items-center justify-center py-12 text-center">
-              <div className="w-14 h-14 rounded-xl bg-slate-700/50 border border-slate-600/30 flex items-center justify-center mb-4">
-                <ArrowUpDown size={24} className="text-slate-500" />
-              </div>
-              <p className="text-sm text-slate-500 max-w-xs">
-                {isElectron
-                  ? 'Configure your paths and click Start to begin organizing your audiobooks'
-                  : 'Review the configured paths and click Start to begin organizing your audiobooks'}
-              </p>
-            </div>
-          )}
-
-          {(sorting || progress) && (
-            <div className="space-y-5">
-              {/* Progress Bar */}
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <span className="text-xs text-slate-400">
-                    {isComplete ? 'Complete' : isCanceled ? 'Canceled' : hasError ? 'Error' : 'Sorting...'}
-                  </span>
-                  <span className="text-xs font-bold text-brand-400">
-                    {(progress?.percentage || 0).toFixed(1)}%
-                  </span>
-                </div>
-                <div className="h-2.5 bg-slate-700/60 rounded-full overflow-hidden">
-                  <div
-                    className={`h-full rounded-full transition-all duration-500 ease-out ${
-                      hasError
-                        ? 'bg-red-500'
-                        : isCanceled
-                        ? 'bg-amber-500'
-                        : isComplete
-                        ? 'bg-emerald-500'
-                        : 'bg-gradient-to-r from-brand-600 to-brand-400'
-                    }`}
-                    style={{ width: `${progress?.percentage || 0}%` }}
-                  />
-                </div>
-              </div>
-
-              {/* Stats */}
-              <div className="grid grid-cols-2 xl:grid-cols-5 gap-3">
-                <StatCard label="Total" value={progress?.totalBooks || 0} />
-                <StatCard
-                  label="Copied"
-                  value={progress?.copiedBooks || 0}
-                  color="text-emerald-400"
-                />
-                <StatCard
-                  label="Updated"
-                  value={updatedCount}
-                  color={updatedCount ? 'text-sky-400' : 'text-slate-400'}
-                />
-                <StatCard label="Skipped" value={skippedCount} color="text-amber-400" />
-                <StatCard
-                  label="Failed"
-                  value={progress?.failedBooks || 0}
-                  color={progress?.failedBooks ? 'text-red-400' : 'text-slate-400'}
-                />
-              </div>
-
-              {warningCount > 0 && (
-                <p className="text-xs text-amber-400/80">
-                  {warningCount} warning{warningCount === 1 ? '' : 's'} recorded. See the backend log for details.
-                </p>
-              )}
-
-              {/* Current File */}
-              {progress?.currentTitle && !isComplete && (
-                <div className="bg-slate-800/50 rounded-lg px-4 py-3 border border-slate-700/30">
-                  <p className="text-[11px] text-slate-500 mb-0.5">Current file</p>
-                  <div className="space-y-1.5">
-                    {progressDetails.length > 0 ? (
-                      progressDetails.map(({ label, value }) => (
-                        <div key={label} className="flex items-start gap-2 text-sm">
-                          <span className="text-slate-500 shrink-0 min-w-12">{label}</span>
-                          <span className="text-slate-300 break-all">{value}</span>
-                        </div>
-                      ))
-                    ) : (
-                      <p className="text-sm text-slate-300 break-all">{progress.currentTitle}</p>
+            {PATHS.map(({ key, label, icon, picker }) => (
+              <Field key={key} label={label}>
+                {(id) => (
+                  <div className="flex gap-2">
+                    <PathInput
+                      id={id}
+                      icon={icon}
+                      value={config[key]}
+                      placeholder={isElectron ? 'Not selected' : 'Configured by the server'}
+                    />
+                    {isElectron && (
+                      <Button onClick={() => browse(key, picker)} disabled={sorting}>
+                        Browse
+                      </Button>
                     )}
                   </div>
-                </div>
-              )}
+                )}
+              </Field>
+            ))}
 
-              {/* Complete State */}
-              {isComplete && (
-                <div className="bg-emerald-500/10 border border-emerald-500/20 rounded-lg px-4 py-4 flex items-center gap-3">
-                  <CheckCircle2 size={20} className="text-emerald-400 shrink-0" />
-                  <div>
-                    <p className="text-sm font-medium text-emerald-300">Sorting complete!</p>
-                    <p className="text-xs text-emerald-400/70 mt-0.5">
-                      {progress.copiedBooks} book{progress.copiedBooks !== 1 ? 's' : ''} copied
-                      {updatedCount > 0 && `, ${updatedCount} of them updated in place`}
-                      {skippedCount > 0 && `, ${skippedCount} already up to date or unmatched`}
-                      {progress.failedBooks > 0 && `, ${progress.failedBooks} failed`}
-                    </p>
-                  </div>
-                </div>
+            <Field label="Update check" hint={selectedMode?.description} group>
+              {() => (
+                <SegmentedControl
+                  label="Update check"
+                  name="comparison-mode"
+                  value={comparisonMode}
+                  options={COMPARISON_MODES}
+                  disabled={sorting}
+                  onChange={(value) => setConfig((prev) => ({ ...prev, comparisonMode: value }))}
+                />
               )}
+            </Field>
+          </div>
 
-              {isCanceled && (
-                <div className="bg-amber-500/10 border border-amber-500/20 rounded-lg px-4 py-4 flex items-center gap-3">
-                  <AlertCircle size={20} className="text-amber-400 shrink-0" />
-                  <div>
-                    <p className="text-sm font-medium text-amber-300">Sorting canceled</p>
-                    <p className="text-xs text-amber-400/70 mt-0.5">
-                      {progress?.copiedBooks || 0} file{(progress?.copiedBooks || 0) !== 1 ? 's' : ''} copied before cancellation
-                    </p>
-                  </div>
-                </div>
-              )}
+          {error && <Banner tone="critical" className="mt-4">{error}</Banner>}
 
-              {/* Error State */}
-              {hasError && (
-                <div className="bg-red-500/10 border border-red-500/20 rounded-lg px-4 py-4 flex items-center gap-3">
-                  <AlertCircle size={20} className="text-red-400 shrink-0" />
-                  <div>
-                    <p className="text-sm font-medium text-red-300">Sort failed</p>
-                    <p className="text-xs text-red-400/70 mt-0.5">{progress.error}</p>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
+          <div className="mt-5 flex gap-2">
+            <Button variant="primary" icon={Play} className="flex-1" loading={sorting} disabled={!ready} onClick={start}>
+              {sorting ? 'Sorting' : 'Start sorting'}
+            </Button>
+            {sorting && (
+              <Button icon={Square} onClick={cancel}>
+                Cancel
+              </Button>
+            )}
+          </div>
+        </Card>
+
+        <ProgressCard sorting={sorting} progress={progress} />
       </div>
     </div>
   );
 }
 
-function StatCard({ label, value, color = 'text-white' }) {
+function ProgressCard({ sorting, progress }) {
+  if (!sorting && !progress) {
+    return (
+      <Card title="Progress">
+        <p className="py-8 text-center text-sm text-fg-subtle">
+          Progress will appear here once a sort starts.
+        </p>
+      </Card>
+    );
+  }
+
+  const canceled = progress?.isCanceled;
+  const failed = progress?.error;
+  const complete = progress?.isComplete && !failed && !canceled;
+
+  const copied = progress?.copiedBooks || 0;
+  const updated = progress?.updatedBooks || 0;
+  const failedCount = progress?.failedBooks || 0;
+  const skipped =
+    progress?.skippedBooks ?? Math.max(0, (progress?.currentBook || 0) - copied);
+  const warnings = progress?.warningCount || 0;
+
+  const status = failed ? 'Failed' : canceled ? 'Canceled' : complete ? 'Complete' : 'Sorting';
+  const tone = failed ? 'critical' : canceled ? 'caution' : complete ? 'positive' : 'accent';
+
   return (
-    <div className="bg-slate-800/50 rounded-lg px-4 py-3 border border-slate-700/30">
-      <p className="text-[11px] text-slate-500 mb-0.5">{label}</p>
-      <p className={`text-lg font-bold ${color}`}>{value.toLocaleString()}</p>
-    </div>
+    <Card title="Progress">
+      <div className="space-y-5">
+        <div>
+          <div className="mb-2 flex items-baseline justify-between">
+            <span className="text-sm text-fg-muted">{status}</span>
+            <span className="tabular text-sm font-medium text-fg">
+              {(progress?.percentage || 0).toFixed(0)}%
+            </span>
+          </div>
+          <ProgressBar value={progress?.percentage} tone={tone} label={`Sort progress: ${status}`} />
+          {progress?.totalBooks > 0 && (
+            <p className="tabular mt-2 text-2xs text-fg-subtle">
+              {(progress.currentBook || 0).toLocaleString()} of {progress.totalBooks.toLocaleString()} books
+            </p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <Stat label="Copied" value={copied} tone="positive" />
+          <Stat label="Updated" value={updated} tone="accent" />
+          <Stat label="Skipped" value={skipped} tone="caution" />
+          <Stat label="Failed" value={failedCount} tone="critical" />
+        </div>
+
+        {progress?.currentTitle && !progress?.isComplete && (
+          <CurrentBook label={progress.currentTitle} />
+        )}
+
+        {complete && (
+          <Banner tone="positive">
+            {copied.toLocaleString()} book{copied === 1 ? '' : 's'} copied
+            {updated > 0 && `, ${updated.toLocaleString()} updated in place`}
+            {skipped > 0 && `, ${skipped.toLocaleString()} already up to date`}
+            {failedCount > 0 && `, ${failedCount.toLocaleString()} failed`}.
+          </Banner>
+        )}
+
+        {canceled && (
+          <Banner tone="caution">
+            Canceled after {copied.toLocaleString()} book{copied === 1 ? '' : 's'}. Files already copied are
+            complete; re-running picks up where this left off.
+          </Banner>
+        )}
+
+        {failed && <Banner tone="critical">{progress.error}</Banner>}
+
+        {warnings > 0 && (
+          <p className="text-2xs text-fg-subtle">
+            {warnings.toLocaleString()} warning{warnings === 1 ? '' : 's'} recorded — see the backend log.
+          </p>
+        )}
+      </div>
+    </Card>
   );
 }
 
-function parseProgressDetails(currentTitle) {
-  if (!currentTitle) return [];
-
-  return currentTitle
+/** The backend sends "Artist: X | Series: Y | Title: Z"; show it as fields rather than a run-on line. */
+function CurrentBook({ label }) {
+  const details = label
     .split('|')
     .map((part) => part.trim())
     .filter(Boolean)
-    .map((part, index) => {
-      const separatorIndex = part.indexOf(':');
-      if (separatorIndex === -1) {
-        return { label: `Item ${index + 1}`, value: part };
-      }
-
-      return {
-        label: part.slice(0, separatorIndex).trim(),
-        value: part.slice(separatorIndex + 1).trim(),
-      };
+    .map((part) => {
+      const separator = part.indexOf(':');
+      return separator === -1
+        ? { label: null, value: part }
+        : { label: part.slice(0, separator).trim(), value: part.slice(separator + 1).trim() };
     });
+
+  return (
+    <div className="rounded border border-line bg-raised px-3.5 py-3">
+      <p className="mb-1.5 text-2xs text-fg-subtle">Current book</p>
+      <dl className="space-y-1">
+        {details.map(({ label: key, value }, index) => (
+          <div key={key ?? index} className="flex gap-2 text-sm">
+            {key && <dt className="w-14 shrink-0 text-fg-subtle">{key}</dt>}
+            <dd className="min-w-0 break-words text-fg-muted">{value}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
 }
+
+export default memo(SortPanel);

--- a/electron-ui/src/components/SortPanel.jsx
+++ b/electron-ui/src/components/SortPanel.jsx
@@ -88,7 +88,6 @@ function SortPanel({ config, setConfig, run, setRun }) {
               {() => (
                 <SegmentedControl
                   label="Update check"
-                  name="comparison-mode"
                   value={comparisonMode}
                   options={COMPARISON_MODES}
                   disabled={sorting}
@@ -114,8 +113,31 @@ function SortPanel({ config, setConfig, run, setRun }) {
 
         <ProgressCard sorting={sorting} progress={progress} />
       </div>
+
+      {/*
+        Always mounted so it is being observed before the text arrives. The banners below announce
+        nothing on their own: they are mounted at the same instant as their message, and a live
+        region that appears together with its content is routinely missed.
+      */}
+      <p aria-live="polite" className="sr-only">
+        {outcomeAnnouncement(run)}
+      </p>
     </div>
   );
+}
+
+/** One sentence describing how the run ended, for the live region. Empty while it is still going. */
+function outcomeAnnouncement({ sorting, progress, error }) {
+  if (error) return `Sort failed: ${error}`;
+  if (sorting || !progress?.isComplete) return '';
+
+  const copied = progress.copiedBooks || 0;
+  const failed = progress.failedBooks || 0;
+
+  if (progress.error) return `Sort failed: ${progress.error}`;
+  if (progress.isCanceled) return `Sort canceled after ${copied} books`;
+
+  return `Sort complete. ${copied} copied${failed > 0 ? `, ${failed} failed` : ''}.`;
 }
 
 function ProgressCard({ sorting, progress }) {

--- a/electron-ui/src/components/SortPanel.jsx
+++ b/electron-ui/src/components/SortPanel.jsx
@@ -12,6 +12,9 @@ import {
 } from 'lucide-react';
 import { startSort, getSortProgress, cancelSort } from '../api';
 
+const POLL_INTERVAL_MS = 400;
+const MAX_POLL_FAILURES = 25; // ~10 seconds of silence before giving up
+
 export default function SortPanel({ books, sortState, setSortState }) {
   const { csvPath, sourcePath, destPath, sorting, progress, error } = sortState;
   const pollRef = useRef(null);
@@ -65,21 +68,40 @@ export default function SortPanel({ books, sortState, setSortState }) {
 
   const startPolling = useCallback(() => {
     if (pollRef.current) clearInterval(pollRef.current);
+
+    // A transient failure is normal; a run of them means the backend is gone, and spinning
+    // "Sorting..." forever is worse than saying so.
+    let consecutiveFailures = 0;
+
+    const stop = () => {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    };
+
     pollRef.current = setInterval(async () => {
       try {
         const p = await getSortProgress();
+        consecutiveFailures = 0;
+
         const patches = { progress: p };
         if (p.isComplete) {
-          clearInterval(pollRef.current);
-          pollRef.current = null;
+          stop();
           patches.sorting = false;
           if (p.error) patches.error = p.error;
         }
         setSortState((prev) => ({ ...prev, ...patches }));
-      } catch {
-        // Ignore polling errors
+      } catch (err) {
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= MAX_POLL_FAILURES) {
+          stop();
+          setSortState((prev) => ({
+            ...prev,
+            sorting: false,
+            error: `Lost contact with the backend while sorting: ${err.message}`,
+          }));
+        }
       }
-    }, 400);
+    }, POLL_INTERVAL_MS);
   }, [setSortState]);
 
   // Resume polling when component remounts while a sort is still active
@@ -99,6 +121,12 @@ export default function SortPanel({ books, sortState, setSortState }) {
   const isComplete = progress?.isComplete && !progress?.error && !isCanceled;
   const hasError = progress?.error;
   const progressDetails = parseProgressDetails(progress?.currentTitle);
+  const warningCount = progress?.warningCount || 0;
+
+  // skippedBooks was added alongside failedBooks; fall back for an older backend.
+  const skippedCount =
+    progress?.skippedBooks ??
+    Math.max(0, (progress?.currentBook || 0) - (progress?.copiedBooks || 0));
 
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-y-auto">
@@ -272,21 +300,26 @@ export default function SortPanel({ books, sortState, setSortState }) {
               </div>
 
               {/* Stats */}
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 xl:grid-cols-4 gap-3">
                 <StatCard label="Total" value={progress?.totalBooks || 0} />
                 <StatCard
                   label="Copied"
                   value={progress?.copiedBooks || 0}
                   color="text-emerald-400"
                 />
+                <StatCard label="Skipped" value={skippedCount} color="text-amber-400" />
                 <StatCard
-                  label="Skipped"
-                  value={
-                    (progress?.currentBook || 0) - (progress?.copiedBooks || 0)
-                  }
-                  color="text-amber-400"
+                  label="Failed"
+                  value={progress?.failedBooks || 0}
+                  color={progress?.failedBooks ? 'text-red-400' : 'text-slate-400'}
                 />
               </div>
+
+              {warningCount > 0 && (
+                <p className="text-xs text-amber-400/80">
+                  {warningCount} warning{warningCount === 1 ? '' : 's'} recorded. See the backend log for details.
+                </p>
+              )}
 
               {/* Current File */}
               {progress?.currentTitle && !isComplete && (
@@ -314,7 +347,9 @@ export default function SortPanel({ books, sortState, setSortState }) {
                   <div>
                     <p className="text-sm font-medium text-emerald-300">Sorting complete!</p>
                     <p className="text-xs text-emerald-400/70 mt-0.5">
-                      {progress.copiedBooks} file{progress.copiedBooks !== 1 ? 's' : ''} copied successfully
+                      {progress.copiedBooks} book{progress.copiedBooks !== 1 ? 's' : ''} copied
+                      {skippedCount > 0 && `, ${skippedCount} already up to date or unmatched`}
+                      {progress.failedBooks > 0 && `, ${progress.failedBooks} failed`}
                     </p>
                   </div>
                 </div>

--- a/electron-ui/src/components/SortPanel.jsx
+++ b/electron-ui/src/components/SortPanel.jsx
@@ -9,14 +9,32 @@ import {
   AlertCircle,
   Loader2,
   ArrowUpDown,
+  Gauge,
+  ShieldCheck,
 } from 'lucide-react';
 import { startSort, getSortProgress, cancelSort } from '../api';
 
 const POLL_INTERVAL_MS = 400;
 const MAX_POLL_FAILURES = 25; // ~10 seconds of silence before giving up
 
+const COMPARISON_MODES = [
+  {
+    value: 'quick',
+    label: 'Quick',
+    description:
+      'Replaces a book when its size or sampled contents differ. Fast, and catches almost every re-release.',
+  },
+  {
+    value: 'full',
+    label: 'Verify contents',
+    description:
+      'Compares every byte and replaces any book that changed. Slower, but never leaves a stale copy behind.',
+  },
+];
+
 export default function SortPanel({ books, sortState, setSortState }) {
   const { csvPath, sourcePath, destPath, sorting, progress, error } = sortState;
+  const comparisonMode = sortState.comparisonMode === 'full' ? 'full' : 'quick';
   const pollRef = useRef(null);
   const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
 
@@ -50,7 +68,7 @@ export default function SortPanel({ books, sortState, setSortState }) {
     update({ error: null, sorting: true, progress: null });
 
     try {
-      await startSort(csvPath, sourcePath, destPath);
+      await startSort(csvPath, sourcePath, destPath, comparisonMode);
       startPolling();
     } catch (err) {
       update({ error: err.message, sorting: false });
@@ -122,6 +140,8 @@ export default function SortPanel({ books, sortState, setSortState }) {
   const hasError = progress?.error;
   const progressDetails = parseProgressDetails(progress?.currentTitle);
   const warningCount = progress?.warningCount || 0;
+
+  const updatedCount = progress?.updatedBooks || 0;
 
   // skippedBooks was added alongside failedBooks; fall back for an older backend.
   const skippedCount =
@@ -214,6 +234,40 @@ export default function SortPanel({ books, sortState, setSortState }) {
                 )}
               </div>
             </div>
+
+            {/* Update check */}
+            <div>
+              <label className="block text-xs font-medium text-slate-400 mb-1.5">
+                Update check
+              </label>
+              <div
+                role="radiogroup"
+                aria-label="Update check"
+                className="flex gap-1 p-1 bg-slate-800/80 border border-slate-600/50 rounded-lg"
+              >
+                {COMPARISON_MODES.map((mode) => (
+                  <button
+                    key={mode.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={comparisonMode === mode.value}
+                    disabled={sorting}
+                    onClick={() => update({ comparisonMode: mode.value })}
+                    className={`flex-1 inline-flex items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+                      comparisonMode === mode.value
+                        ? 'bg-brand-600 text-white'
+                        : 'text-slate-300 hover:bg-slate-700/60'
+                    }`}
+                  >
+                    {mode.value === 'full' ? <ShieldCheck size={14} /> : <Gauge size={14} />}
+                    {mode.label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-[11px] text-slate-500 mt-1.5">
+                {COMPARISON_MODES.find((mode) => mode.value === comparisonMode)?.description}
+              </p>
+            </div>
           </div>
 
           {error && (
@@ -300,12 +354,17 @@ export default function SortPanel({ books, sortState, setSortState }) {
               </div>
 
               {/* Stats */}
-              <div className="grid grid-cols-2 xl:grid-cols-4 gap-3">
+              <div className="grid grid-cols-2 xl:grid-cols-5 gap-3">
                 <StatCard label="Total" value={progress?.totalBooks || 0} />
                 <StatCard
                   label="Copied"
                   value={progress?.copiedBooks || 0}
                   color="text-emerald-400"
+                />
+                <StatCard
+                  label="Updated"
+                  value={updatedCount}
+                  color={updatedCount ? 'text-sky-400' : 'text-slate-400'}
                 />
                 <StatCard label="Skipped" value={skippedCount} color="text-amber-400" />
                 <StatCard
@@ -348,6 +407,7 @@ export default function SortPanel({ books, sortState, setSortState }) {
                     <p className="text-sm font-medium text-emerald-300">Sorting complete!</p>
                     <p className="text-xs text-emerald-400/70 mt-0.5">
                       {progress.copiedBooks} book{progress.copiedBooks !== 1 ? 's' : ''} copied
+                      {updatedCount > 0 && `, ${updatedCount} of them updated in place`}
                       {skippedCount > 0 && `, ${skippedCount} already up to date or unmatched`}
                       {progress.failedBooks > 0 && `, ${progress.failedBooks} failed`}
                     </p>

--- a/electron-ui/src/components/TitleBar.jsx
+++ b/electron-ui/src/components/TitleBar.jsx
@@ -1,59 +1,62 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Minus, Square, X, Copy } from 'lucide-react';
+import { useIsElectron } from '../hooks';
+
+function WindowButton({ label, onClick, danger = false, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      title={label}
+      className={[
+        'flex h-9 w-11 items-center justify-center text-fg-muted transition-colors',
+        danger ? 'hover:bg-critical hover:text-white' : 'hover:bg-raised hover:text-fg',
+      ].join(' ')}
+    >
+      {children}
+    </button>
+  );
+}
 
 export default function TitleBar() {
+  const isElectron = useIsElectron();
   const [isMaximized, setIsMaximized] = useState(false);
-  const isElectron = typeof window !== 'undefined' && !!window.electronAPI;
 
-  const handleMinimize = () => window.electronAPI?.minimize();
+  useEffect(() => {
+    if (!isElectron) return;
+    // Ask once on mount: the window can start maximised, and assuming otherwise shows the wrong
+    // restore/maximise glyph until the user clicks it.
+    window.electronAPI?.isMaximized().then((value) => setIsMaximized(!!value));
+  }, [isElectron]);
+
   const handleMaximize = async () => {
     await window.electronAPI?.maximize();
-    setIsMaximized(await window.electronAPI?.isMaximized());
+    setIsMaximized(!!(await window.electronAPI?.isMaximized()));
   };
-  const handleClose = () => window.electronAPI?.close();
-
-  if (!isElectron) {
-    return (
-      <header className="h-10 bg-slate-900/90 border-b border-slate-800 flex items-center px-4 select-none shrink-0">
-        <div className="flex items-center gap-2.5">
-          <div className="w-5 h-5 rounded-md bg-gradient-to-br from-brand-500 to-violet-500 flex items-center justify-center">
-            <span className="text-[10px]">OA</span>
-          </div>
-          <span className="text-xs font-medium text-slate-400">OpenAudible Book Organizer</span>
-        </div>
-      </header>
-    );
-  }
 
   return (
-    <header className="titlebar-drag h-10 bg-slate-900/90 border-b border-slate-800 flex items-center justify-between px-4 select-none shrink-0">
-      <div className="flex items-center gap-2.5">
-        <div className="w-5 h-5 rounded-md bg-gradient-to-br from-brand-500 to-violet-500 flex items-center justify-center">
-          <span className="text-[10px]">🎧</span>
-        </div>
-        <span className="text-xs font-medium text-slate-400">OpenAudible Book Organizer</span>
-      </div>
+    <header
+      className={[
+        'flex h-9 shrink-0 select-none items-center justify-between border-b border-line bg-canvas pl-4',
+        isElectron ? 'titlebar-drag' : 'pr-4',
+      ].join(' ')}
+    >
+      <span className="text-xs text-fg-subtle">OpenAudible Book Organizer</span>
 
-      <div className="titlebar-no-drag flex items-center">
-        <button
-          onClick={handleMinimize}
-          className="w-11 h-10 flex items-center justify-center text-slate-400 hover:bg-slate-700/60 hover:text-slate-200 transition-colors"
-        >
-          <Minus size={14} />
-        </button>
-        <button
-          onClick={handleMaximize}
-          className="w-11 h-10 flex items-center justify-center text-slate-400 hover:bg-slate-700/60 hover:text-slate-200 transition-colors"
-        >
-          {isMaximized ? <Copy size={12} /> : <Square size={12} />}
-        </button>
-        <button
-          onClick={handleClose}
-          className="w-11 h-10 flex items-center justify-center text-slate-400 hover:bg-red-600 hover:text-white transition-colors"
-        >
-          <X size={14} />
-        </button>
-      </div>
+      {isElectron && (
+        <div className="titlebar-no-drag flex items-center">
+          <WindowButton label="Minimise" onClick={() => window.electronAPI?.minimize()}>
+            <Minus size={14} aria-hidden="true" />
+          </WindowButton>
+          <WindowButton label={isMaximized ? 'Restore' : 'Maximise'} onClick={handleMaximize}>
+            {isMaximized ? <Copy size={12} aria-hidden="true" /> : <Square size={12} aria-hidden="true" />}
+          </WindowButton>
+          <WindowButton label="Close" onClick={() => window.electronAPI?.close()} danger>
+            <X size={14} aria-hidden="true" />
+          </WindowButton>
+        </div>
+      )}
     </header>
   );
 }

--- a/electron-ui/src/components/ui/Button.jsx
+++ b/electron-ui/src/components/ui/Button.jsx
@@ -1,0 +1,48 @@
+import { Loader2 } from 'lucide-react';
+
+const VARIANTS = {
+  primary: 'bg-accent text-accent-fg font-medium hover:bg-accent-hover',
+  secondary: 'bg-raised text-fg border border-line-strong hover:bg-line',
+  ghost: 'text-fg-muted hover:bg-raised hover:text-fg',
+  danger: 'bg-raised text-critical border border-line-strong hover:bg-critical/10',
+};
+
+/**
+ * The only button in the app. Every variant is the same height so buttons, inputs and selects
+ * sit on one line without per-site padding overrides.
+ */
+export default function Button({
+  variant = 'secondary',
+  icon: Icon,
+  loading = false,
+  disabled = false,
+  children,
+  className = '',
+  type = 'button',
+  ...props
+}) {
+  const iconOnly = !children;
+
+  return (
+    <button
+      type={type}
+      disabled={disabled || loading}
+      className={[
+        'inline-flex h-control shrink-0 items-center justify-center gap-2 rounded',
+        'text-sm transition-colors duration-150',
+        'disabled:cursor-not-allowed disabled:opacity-45',
+        iconOnly ? 'w-control' : 'px-3.5',
+        VARIANTS[variant],
+        className,
+      ].join(' ')}
+      {...props}
+    >
+      {loading ? (
+        <Loader2 size={15} className="animate-spin" aria-hidden="true" />
+      ) : (
+        Icon && <Icon size={15} aria-hidden="true" />
+      )}
+      {children}
+    </button>
+  );
+}

--- a/electron-ui/src/components/ui/Field.jsx
+++ b/electron-ui/src/components/ui/Field.jsx
@@ -1,0 +1,95 @@
+import { useId, useLayoutEffect, useRef } from 'react';
+
+/**
+ * A labelled control. The label is bound to the control by id rather than by wrapping, so the
+ * control can sit beside a button in the same row.
+ *
+ * Set `group` when the child is a composite (a radiogroup, say) rather than a single form control:
+ * a <label for> pointing at a group is not a valid association, and the group carries its own
+ * accessible name instead.
+ */
+export function Field({ label, hint, group = false, children, className = '' }) {
+  const id = useId();
+
+  return (
+    <div className={className}>
+      {group ? (
+        <span className="mb-1.5 block text-xs font-medium text-fg-muted">{label}</span>
+      ) : (
+        <label htmlFor={id} className="mb-1.5 block text-xs font-medium text-fg-muted">
+          {label}
+        </label>
+      )}
+      {children(id)}
+      {hint && <p className="mt-1.5 text-2xs text-fg-subtle">{hint}</p>}
+    </div>
+  );
+}
+
+/**
+ * A read-only path display with an optional leading icon.
+ *
+ * The end of a path is the part that identifies it, so the field is scrolled to its end rather
+ * than showing the first few characters of a long home directory. Scrolling rather than
+ * `direction: rtl`, which does keep the tail in view but reorders the leading separator to the
+ * wrong end, rendering "/home/me/books.csv" as "home/me/books.csv/".
+ */
+export function PathInput({ id, value, placeholder, icon: Icon, invalid = false }) {
+  const inputRef = useRef(null);
+
+  useLayoutEffect(() => {
+    const input = inputRef.current;
+    if (input) input.scrollLeft = input.scrollWidth;
+  }, [value]);
+
+  return (
+    <div className="relative min-w-0 flex-1">
+      {Icon && (
+        <Icon
+          size={14}
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-fg-subtle"
+        />
+      )}
+      <input
+        ref={inputRef}
+        id={id}
+        type="text"
+        readOnly
+        value={value}
+        placeholder={placeholder}
+        title={value || undefined}
+        className={[
+          'h-control w-full rounded border bg-surface pr-3 text-sm text-fg-muted',
+          'placeholder:text-fg-subtle',
+          Icon ? 'pl-9' : 'pl-3',
+          invalid ? 'border-critical/50' : 'border-line',
+        ].join(' ')}
+      />
+    </div>
+  );
+}
+
+export function TextInput({ id, icon: Icon, className = '', ...props }) {
+  return (
+    <div className={`relative ${className}`}>
+      {Icon && (
+        <Icon
+          size={14}
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-fg-subtle"
+        />
+      )}
+      <input
+        id={id}
+        className={[
+          'h-control w-full rounded border border-line bg-surface pr-3 text-sm text-fg',
+          'placeholder:text-fg-subtle',
+          'focus:border-accent/60',
+          Icon ? 'pl-9' : 'pl-3',
+        ].join(' ')}
+        {...props}
+      />
+    </div>
+  );
+}

--- a/electron-ui/src/components/ui/SegmentedControl.jsx
+++ b/electron-ui/src/components/ui/SegmentedControl.jsx
@@ -1,22 +1,39 @@
+import { useRef } from 'react';
+
 /**
  * A two-or-more way choice, rendered as a real radiogroup so arrow keys move between options and
  * screen readers announce the selection. Roving tabindex keeps the group a single tab stop.
  */
-export default function SegmentedControl({ label, value, options, onChange, disabled = false, name }) {
+export default function SegmentedControl({ label, value, options, onChange, disabled = false }) {
+  const buttonRefs = useRef([]);
   const currentIndex = Math.max(0, options.findIndex((option) => option.value === value));
 
-  const move = (delta) => {
-    const next = options[(currentIndex + delta + options.length) % options.length];
-    if (next) onChange(next.value);
+  const select = (index) => {
+    const next = options[index];
+    if (!next) return;
+
+    onChange(next.value);
+    // Focus has to follow the selection. Without this the user is left on the option they moved
+    // away from, which now reports aria-checked="false" — so a screen reader announces the
+    // deselected option and never names the one that was actually chosen.
+    buttonRefs.current[index]?.focus();
   };
 
   const handleKeyDown = (event) => {
-    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+    const { key } = event;
+
+    if (key === 'ArrowRight' || key === 'ArrowDown') {
       event.preventDefault();
-      move(1);
-    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      select((currentIndex + 1) % options.length);
+    } else if (key === 'ArrowLeft' || key === 'ArrowUp') {
       event.preventDefault();
-      move(-1);
+      select((currentIndex - 1 + options.length) % options.length);
+    } else if (key === 'Home') {
+      event.preventDefault();
+      select(0);
+    } else if (key === 'End') {
+      event.preventDefault();
+      select(options.length - 1);
     }
   };
 
@@ -27,16 +44,18 @@ export default function SegmentedControl({ label, value, options, onChange, disa
       onKeyDown={handleKeyDown}
       className="flex gap-1 rounded border border-line bg-surface p-1"
     >
-      {options.map((option) => {
+      {options.map((option, index) => {
         const selected = option.value === value;
         const Icon = option.icon;
 
         return (
           <button
             key={option.value}
+            ref={(element) => {
+              buttonRefs.current[index] = element;
+            }}
             type="button"
             role="radio"
-            name={name}
             aria-checked={selected}
             tabIndex={selected ? 0 : -1}
             disabled={disabled}
@@ -45,7 +64,7 @@ export default function SegmentedControl({ label, value, options, onChange, disa
               'inline-flex flex-1 items-center justify-center gap-1.5 rounded-sm px-3 py-1.5',
               'text-sm transition-colors duration-150',
               'disabled:cursor-not-allowed disabled:opacity-45',
-              selected ? 'bg-accent text-accent-fg font-medium' : 'text-fg-muted hover:bg-raised hover:text-fg',
+              selected ? 'bg-accent font-medium text-accent-fg' : 'text-fg-muted hover:bg-raised hover:text-fg',
             ].join(' ')}
           >
             {Icon && <Icon size={14} aria-hidden="true" />}

--- a/electron-ui/src/components/ui/SegmentedControl.jsx
+++ b/electron-ui/src/components/ui/SegmentedControl.jsx
@@ -1,0 +1,58 @@
+/**
+ * A two-or-more way choice, rendered as a real radiogroup so arrow keys move between options and
+ * screen readers announce the selection. Roving tabindex keeps the group a single tab stop.
+ */
+export default function SegmentedControl({ label, value, options, onChange, disabled = false, name }) {
+  const currentIndex = Math.max(0, options.findIndex((option) => option.value === value));
+
+  const move = (delta) => {
+    const next = options[(currentIndex + delta + options.length) % options.length];
+    if (next) onChange(next.value);
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      move(1);
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      move(-1);
+    }
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      onKeyDown={handleKeyDown}
+      className="flex gap-1 rounded border border-line bg-surface p-1"
+    >
+      {options.map((option) => {
+        const selected = option.value === value;
+        const Icon = option.icon;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            name={name}
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            disabled={disabled}
+            onClick={() => onChange(option.value)}
+            className={[
+              'inline-flex flex-1 items-center justify-center gap-1.5 rounded-sm px-3 py-1.5',
+              'text-sm transition-colors duration-150',
+              'disabled:cursor-not-allowed disabled:opacity-45',
+              selected ? 'bg-accent text-accent-fg font-medium' : 'text-fg-muted hover:bg-raised hover:text-fg',
+            ].join(' ')}
+          >
+            {Icon && <Icon size={14} aria-hidden="true" />}
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/electron-ui/src/components/ui/Surface.jsx
+++ b/electron-ui/src/components/ui/Surface.jsx
@@ -1,0 +1,109 @@
+import { AlertCircle, CheckCircle2, Info } from 'lucide-react';
+
+/** A plain panel. Flat, hairline border, no blur or glow. */
+export function Card({ title, description, actions, children, className = '', bodyClassName = '' }) {
+  return (
+    <section className={`flex min-h-0 flex-col rounded-lg border border-line bg-surface ${className}`}>
+      {(title || actions) && (
+        <header className="flex items-start justify-between gap-4 border-b border-line px-5 py-3.5">
+          <div className="min-w-0">
+            {title && <h2 className="text-base font-semibold text-fg">{title}</h2>}
+            {description && <p className="mt-0.5 text-xs text-fg-muted">{description}</p>}
+          </div>
+          {actions && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+        </header>
+      )}
+      <div className={`min-h-0 flex-1 p-5 ${bodyClassName}`}>{children}</div>
+    </section>
+  );
+}
+
+const BANNER_TONES = {
+  critical: { icon: AlertCircle, cls: 'border-critical/30 bg-critical/10 text-critical' },
+  caution: { icon: Info, cls: 'border-caution/30 bg-caution/10 text-caution' },
+  positive: { icon: CheckCircle2, cls: 'border-positive/30 bg-positive/10 text-positive' },
+};
+
+/**
+ * An inline message. Every tone carries an icon as well as a colour, so the meaning survives for
+ * anyone who cannot distinguish the hues.
+ */
+export function Banner({ tone = 'critical', children, className = '' }) {
+  const { icon: Icon, cls } = BANNER_TONES[tone] ?? BANNER_TONES.critical;
+
+  return (
+    <div
+      role={tone === 'critical' ? 'alert' : 'status'}
+      className={`flex items-start gap-2.5 rounded border px-3.5 py-2.5 text-sm ${cls} ${className}`}
+    >
+      <Icon size={15} className="mt-0.5 shrink-0" aria-hidden="true" />
+      <span className="min-w-0">{children}</span>
+    </div>
+  );
+}
+
+/** Centred placeholder for a view with nothing in it yet. */
+export function EmptyState({ icon: Icon, title, description, children }) {
+  return (
+    <div className="flex flex-1 items-center justify-center p-8">
+      <div className="max-w-sm text-center">
+        {Icon && (
+          <div className="mx-auto mb-5 flex h-12 w-12 items-center justify-center rounded-lg border border-line bg-raised">
+            <Icon size={22} className="text-fg-muted" aria-hidden="true" />
+          </div>
+        )}
+        <h2 className="text-base font-semibold text-fg">{title}</h2>
+        {description && <p className="mx-auto mt-2 text-sm leading-relaxed text-fg-muted">{description}</p>}
+        {children && <div className="mt-6 flex flex-col items-center gap-3">{children}</div>}
+      </div>
+    </div>
+  );
+}
+
+const STAT_TONES = {
+  default: 'text-fg',
+  accent: 'text-accent',
+  positive: 'text-positive',
+  caution: 'text-caution',
+  critical: 'text-critical',
+};
+
+/** One number with its label. Muted when zero so the eye lands on what actually happened. */
+export function Stat({ label, value, tone = 'default' }) {
+  const isZero = value === 0;
+
+  return (
+    <div className="rounded border border-line bg-raised px-3 py-2.5">
+      <p className="text-2xs text-fg-subtle">{label}</p>
+      <p className={`tabular mt-0.5 text-lg font-semibold ${isZero ? 'text-fg-subtle' : STAT_TONES[tone]}`}>
+        {typeof value === 'number' ? value.toLocaleString() : value}
+      </p>
+    </div>
+  );
+}
+
+export function ProgressBar({ value, tone = 'accent', label }) {
+  const clamped = Math.max(0, Math.min(100, value || 0));
+  const fill = {
+    accent: 'bg-accent',
+    positive: 'bg-positive',
+    caution: 'bg-caution',
+    critical: 'bg-critical',
+  }[tone];
+
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={Math.round(clamped)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={label}
+      className="h-1.5 w-full overflow-hidden rounded-full bg-line"
+    >
+      <div
+        className={`h-full rounded-full transition-[width] duration-300 ease-out ${fill}`}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}

--- a/electron-ui/src/format.js
+++ b/electron-ui/src/format.js
@@ -1,0 +1,21 @@
+// OpenAudible writes durations as prose: "12 hrs and 34 mins", "45 mins", "1 hr and 1 min".
+// At column width that truncates to "12 hrs and…", which tells the reader nothing, so it is
+// rewritten compactly and the raw value kept as the cell's tooltip.
+const DURATION_PATTERN = /(?:(\d+)\s*h(?:ou)?rs?)?\D*(?:(\d+)\s*min(?:ute)?s?)?/i;
+
+export function formatDuration(raw) {
+  if (!raw) return '—';
+
+  const text = String(raw).trim();
+  const match = DURATION_PATTERN.exec(text);
+  if (!match) return text;
+
+  const hours = Number(match[1] || 0);
+  const minutes = Number(match[2] || 0);
+
+  if (!hours && !minutes) return text;
+  if (!hours) return `${minutes}m`;
+  if (!minutes) return `${hours}h`;
+
+  return `${hours}h ${minutes}m`;
+}

--- a/electron-ui/src/format.js
+++ b/electron-ui/src/format.js
@@ -1,19 +1,40 @@
 // OpenAudible writes durations as prose: "12 hrs and 34 mins", "45 mins", "1 hr and 1 min".
-// At column width that truncates to "12 hrs and…", which tells the reader nothing, so it is
-// rewritten compactly and the raw value kept as the cell's tooltip.
 const DURATION_PATTERN = /(?:(\d+)\s*h(?:ou)?rs?)?\D*(?:(\d+)\s*min(?:ute)?s?)?/i;
 
+/**
+ * Total length in minutes, or null when the value is not a duration we recognise.
+ *
+ * Sorting needs this rather than the text: comparing "45 mins" against "9 hrs and 9 mins" as
+ * strings — even with numeric collation — reads 45 against 9 and files the three quarters of an
+ * hour after the nine hours.
+ */
+export function durationMinutes(raw) {
+  if (!raw) return null;
+
+  const match = DURATION_PATTERN.exec(String(raw).trim());
+  if (!match) return null;
+
+  const hours = Number(match[1] || 0);
+  const minutes = Number(match[2] || 0);
+  if (!hours && !minutes) return null;
+
+  return hours * 60 + minutes;
+}
+
+/**
+ * At column width the raw text truncates to "12 hrs and…", which tells the reader nothing, so it
+ * is rewritten compactly. Anything unrecognised is passed through unchanged rather than dropped.
+ */
 export function formatDuration(raw) {
   if (!raw) return '—';
 
   const text = String(raw).trim();
-  const match = DURATION_PATTERN.exec(text);
-  if (!match) return text;
+  const total = durationMinutes(text);
+  if (total === null) return text;
 
-  const hours = Number(match[1] || 0);
-  const minutes = Number(match[2] || 0);
+  const hours = Math.floor(total / 60);
+  const minutes = total % 60;
 
-  if (!hours && !minutes) return text;
   if (!hours) return `${minutes}m`;
   if (!minutes) return `${hours}h`;
 

--- a/electron-ui/src/hooks/index.js
+++ b/electron-ui/src/hooks/index.js
@@ -1,0 +1,50 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+export { default as useVirtualRows } from './useVirtualRows';
+export { default as useSortRun } from './useSortRun';
+
+/**
+ * Whether the app is running inside Electron rather than a browser tab. Electron-only affordances
+ * (native file pickers, window controls) hang off this.
+ */
+export function useIsElectron() {
+  // Read once: window.electronAPI is injected by the preload script before React mounts and never
+  // changes afterwards, so re-checking on every render only invites inconsistent branches.
+  const [isElectron] = useState(() => typeof window !== 'undefined' && !!window.electronAPI);
+  return isElectron;
+}
+
+/**
+ * Delays a rapidly changing value. Filtering a large library on every keystroke re-runs the whole
+ * filter-and-sort pass; waiting for a pause in typing keeps the field responsive.
+ */
+export function useDebounced(value, delay = 150) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}
+
+/** The observed width of an element, for choosing what fits rather than guessing from the viewport. */
+export function useElementWidth() {
+  const ref = useRef(null);
+  const [width, setWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return undefined;
+
+    setWidth(element.clientWidth);
+
+    const observer = new ResizeObserver(([entry]) => setWidth(entry.contentRect.width));
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  return [ref, width];
+}

--- a/electron-ui/src/hooks/useSortRun.js
+++ b/electron-ui/src/hooks/useSortRun.js
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { cancelSort, getSortProgress, startSort } from '../api';
+
+const POLL_INTERVAL_MS = 400;
+const MAX_POLL_FAILURES = 25; // ~10 seconds of silence before we call the backend gone
+
+/**
+ * Drives one sort run: starting it, polling its progress, and cancelling it.
+ *
+ * The run state lives above this hook so that it survives switching pages — the panel unmounts,
+ * the run does not — and so polling can pick straight back up when the panel comes back.
+ */
+export default function useSortRun({ run, setRun, config }) {
+  const pollRef = useRef(null);
+  // The interval callback is created once but reads the setter every tick; keeping it in a ref
+  // avoids tearing the interval down and rebuilding it whenever the parent re-renders.
+  const setRunRef = useRef(setRun);
+  setRunRef.current = setRun;
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+
+    // A single failed poll is normal — the backend is busy copying. A run of them means it is
+    // gone, and leaving the UI spinning on "Sorting..." forever is worse than saying so.
+    let consecutiveFailures = 0;
+
+    pollRef.current = setInterval(async () => {
+      try {
+        const progress = await getSortProgress();
+        consecutiveFailures = 0;
+
+        if (progress.isComplete) {
+          stopPolling();
+          setRunRef.current((prev) => ({
+            ...prev,
+            progress,
+            sorting: false,
+            error: progress.error || prev.error,
+          }));
+          return;
+        }
+
+        setRunRef.current((prev) => ({ ...prev, progress }));
+      } catch (err) {
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= MAX_POLL_FAILURES) {
+          stopPolling();
+          setRunRef.current((prev) => ({
+            ...prev,
+            sorting: false,
+            error: `Lost contact with the backend while sorting: ${err.message}`,
+          }));
+        }
+      }
+    }, POLL_INTERVAL_MS);
+  }, [stopPolling]);
+
+  // Resume polling when the panel is mounted while a run is still going.
+  useEffect(() => {
+    if (run.sorting && !pollRef.current) {
+      startPolling();
+    }
+
+    return stopPolling;
+  }, [run.sorting, startPolling, stopPolling]);
+
+  const start = useCallback(async () => {
+    const { csvPath, sourcePath, destPath, comparisonMode } = config;
+
+    if (!csvPath || !sourcePath || !destPath) {
+      setRunRef.current((prev) => ({ ...prev, error: 'All three paths are required' }));
+      return;
+    }
+
+    setRunRef.current((prev) => ({ ...prev, error: null, sorting: true, progress: null }));
+
+    try {
+      await startSort(csvPath, sourcePath, destPath, comparisonMode);
+      startPolling();
+    } catch (err) {
+      setRunRef.current((prev) => ({ ...prev, error: err.message, sorting: false }));
+    }
+  }, [config, startPolling]);
+
+  const cancel = useCallback(async () => {
+    try {
+      await cancelSort();
+      setRunRef.current((prev) => ({ ...prev, error: null }));
+    } catch (err) {
+      setRunRef.current((prev) => ({ ...prev, error: err.message }));
+    }
+  }, []);
+
+  return { start, cancel };
+}

--- a/electron-ui/src/hooks/useVirtualRows.js
+++ b/electron-ui/src/hooks/useVirtualRows.js
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * Renders only the rows that are actually on screen.
+ *
+ * A 10,000 book library is perfectly normal, and rendering 10,000 rows costs tens of thousands of
+ * DOM nodes: the first paint stalls for seconds and every scroll frame drops. Windowing keeps the
+ * node count proportional to the viewport instead of the collection, so scrolling stays smooth
+ * whether the library holds fifty books or fifty thousand.
+ *
+ * Written by hand rather than pulled from a package: it is forty lines, and the page is served
+ * under a strict CSP where every added dependency is one more thing to vet.
+ *
+ * @param count      total number of rows
+ * @param rowHeight  fixed pixel height of one row
+ * @param overscan   extra rows rendered above and below the viewport, to cover fast scrolls
+ */
+export default function useVirtualRows({ count, rowHeight, overscan = 6 }) {
+  const scrollRef = useRef(null);
+  const [viewportHeight, setViewportHeight] = useState(0);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return undefined;
+
+    setViewportHeight(element.clientHeight);
+
+    const observer = new ResizeObserver(([entry]) => {
+      setViewportHeight(entry.contentRect.height);
+    });
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return undefined;
+
+    // Coalesce to one update per frame: a trackpad fling fires scroll far more often than the
+    // screen refreshes, and re-rendering on every event is what makes windowed lists feel worse
+    // than the naive version they replaced.
+    let frame = 0;
+    const onScroll = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        setScrollTop(element.scrollTop);
+      });
+    };
+
+    element.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      element.removeEventListener('scroll', onScroll);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  const scrollToTop = useCallback(() => {
+    const element = scrollRef.current;
+    if (element) element.scrollTop = 0;
+    setScrollTop(0);
+  }, []);
+
+  const visibleCount = Math.ceil(viewportHeight / rowHeight) + overscan * 2;
+  const start = Math.max(0, Math.floor(scrollTop / rowHeight) - overscan);
+  const end = Math.min(count, start + visibleCount);
+
+  return {
+    scrollRef,
+    start,
+    end,
+    scrollToTop,
+    paddingTop: start * rowHeight,
+    paddingBottom: Math.max(0, (count - end) * rowHeight),
+  };
+}

--- a/electron-ui/src/index.css
+++ b/electron-ui/src/index.css
@@ -2,25 +2,81 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Design tokens.
+ *
+ * Every colour in the app resolves to one of these. They are stored as raw RGB channels so
+ * Tailwind's opacity modifiers (bg-surface/60) keep working, and they are the single place to
+ * change the palette. Components must not reach for a raw slate-700 style value.
+ */
 @layer base {
+  :root {
+    /* Neutrals, darkest to lightest. */
+    --color-canvas: 12 14 17;
+    --color-surface: 22 25 30;
+    --color-raised: 30 34 40;
+    --color-line: 38 43 50;
+    --color-line-strong: 55 62 71;
+
+    /* Text, in descending emphasis. All three clear WCAG AA on canvas and surface. */
+    --color-fg: 232 235 239;
+    --color-fg-muted: 155 164 175;
+    --color-fg-subtle: 123 133 145;
+
+    /* One accent, used sparingly: the primary action and the current selection. */
+    --color-accent: 88 143 255;
+    --color-accent-hover: 118 164 255;
+    --color-accent-fg: 8 12 20;
+
+    /* Status. Only ever paired with a label or an icon, never colour alone. */
+    --color-positive: 63 185 80;
+    --color-caution: 214 164 60;
+    --color-critical: 248 97 91;
+
+    --radius-sm: 6px;
+    --radius: 8px;
+    --radius-lg: 12px;
+
+    /* Uniform height for every control, so rows of them line up without ad hoc padding. */
+    --control-height: 36px;
+  }
+
   * {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
   }
 
-  html, body, #root {
+  html,
+  body,
+  #root {
     height: 100%;
     overflow: hidden;
   }
 
   body {
-    @apply bg-slate-900 text-slate-100 antialiased;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    @apply bg-canvas text-fg antialiased;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+      sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  /* Counts and durations line up in columns instead of jittering as digits change. */
+  .tabular {
+    font-variant-numeric: tabular-nums;
+  }
+
+  /*
+   * One focus treatment everywhere, and only for keyboard users: :focus alone would ring every
+   * button on click, which is the usual reason apps end up removing focus styles altogether.
+   */
+  :focus-visible {
+    @apply outline-none ring-2 ring-accent/70 ring-offset-2 ring-offset-canvas;
   }
 
   ::-webkit-scrollbar {
-    @apply w-2;
+    @apply h-2 w-2;
   }
 
   ::-webkit-scrollbar-track {
@@ -28,11 +84,21 @@
   }
 
   ::-webkit-scrollbar-thumb {
-    @apply bg-slate-600/50 rounded-full;
+    @apply rounded-full bg-line-strong;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    @apply bg-slate-500/70;
+    @apply bg-fg-subtle;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
   }
 }
 
@@ -43,33 +109,5 @@
 
   .titlebar-no-drag {
     -webkit-app-region: no-drag;
-  }
-
-  .glass-card {
-    @apply bg-slate-800/60 backdrop-blur-sm border border-slate-700/50 rounded-xl;
-  }
-
-  .input-field {
-    @apply w-full bg-slate-800/80 border border-slate-600/50 rounded-lg px-4 py-2.5
-           text-slate-200 placeholder-slate-500
-           focus:outline-none focus:ring-2 focus:ring-brand-500/50 focus:border-brand-500/50
-           transition-all duration-200;
-  }
-
-  .btn-primary {
-    @apply px-6 py-2.5 bg-gradient-to-r from-brand-600 to-brand-500
-           text-white font-medium rounded-lg
-           hover:from-brand-500 hover:to-brand-400
-           focus:outline-none focus:ring-2 focus:ring-brand-500/50
-           disabled:opacity-50 disabled:cursor-not-allowed
-           transition-all duration-200 shadow-lg shadow-brand-500/20;
-  }
-
-  .btn-secondary {
-    @apply px-4 py-2.5 bg-slate-700/80 border border-slate-600/50
-           text-slate-200 font-medium rounded-lg
-           hover:bg-slate-600/80 hover:border-slate-500/50
-           focus:outline-none focus:ring-2 focus:ring-slate-500/50
-           transition-all duration-200;
   }
 }

--- a/electron-ui/src/index.css
+++ b/electron-ui/src/index.css
@@ -18,10 +18,10 @@
     --color-line: 38 43 50;
     --color-line-strong: 55 62 71;
 
-    /* Text, in descending emphasis. All three clear WCAG AA on canvas and surface. */
+    /* Text, in descending emphasis. All three clear WCAG AA 4.5:1 on canvas, surface AND raised. */
     --color-fg: 232 235 239;
-    --color-fg-muted: 155 164 175;
-    --color-fg-subtle: 123 133 145;
+    --color-fg-muted: 161 170 181;
+    --color-fg-subtle: 141 150 161;
 
     /* One accent, used sparingly: the primary action and the current selection. */
     --color-accent: 88 143 255;
@@ -70,9 +70,14 @@
   /*
    * One focus treatment everywhere, and only for keyboard users: :focus alone would ring every
    * button on click, which is the usual reason apps end up removing focus styles altogether.
+   *
+   * A real outline rather than a Tailwind ring: rings are drawn as box-shadows, which ancestors
+   * with hidden overflow clip. The sticky table header sits inside two such containers, and its
+   * focus indicator was losing its top and outer edges.
    */
   :focus-visible {
-    @apply outline-none ring-2 ring-accent/70 ring-offset-2 ring-offset-canvas;
+    outline: 2px solid rgb(var(--color-accent) / 0.9);
+    outline-offset: 2px;
   }
 
   ::-webkit-scrollbar {

--- a/electron-ui/src/sorting.js
+++ b/electron-ui/src/sorting.js
@@ -1,0 +1,64 @@
+import { durationMinutes } from './format';
+
+export const SEARCH_FIELDS = ['title', 'author', 'seriesName', 'narratedBy'];
+
+export const SORT_LABELS = {
+  title: 'title',
+  author: 'author',
+  seriesName: 'series',
+  narratedBy: 'narrator',
+  duration: 'duration',
+  aveRating: 'rating',
+};
+
+// Natural ordering, so "Book 2" sorts before "Book 10" and accented names file where a reader
+// expects. Built once rather than per comparison: constructing a collator is not cheap, and doing
+// it inside the sort callback made large libraries noticeably slow to reorder.
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+/**
+ * What a column sorts on, which is not always the field it is named after.
+ *
+ * A column has to sort by what it shows. Sorting Series on `seriesName` alone left every book in a
+ * series tied, so they kept whatever order the export happened to use — #10 above #2. Sorting
+ * Duration on the raw text put a 45 minute book after a 9 hour one, because "45" reads as larger
+ * than "9". Both are keyed on the meaning of the value rather than its spelling.
+ */
+const SORT_KEYS = {
+  duration: (book) => durationMinutes(book.duration),
+  aveRating: (book) => (book.aveRating > 0 ? book.aveRating : null),
+  seriesName: (book) => (book.seriesName ? `${book.seriesName} #${book.seriesSequence ?? ''}` : null),
+};
+
+export function sortKey(book, field) {
+  return SORT_KEYS[field] ? SORT_KEYS[field](book) : book[field];
+}
+
+const isBlank = (value) => value == null || value === '';
+
+/** Comparator for one column and direction. Books missing the value always collect at the end. */
+export function compareBooks(field, dir) {
+  return (a, b) => {
+    const left = sortKey(a, field);
+    const right = sortKey(b, field);
+
+    // Blanks sink regardless of direction, rather than forming a block of empty rows at the top
+    // whenever the direction is flipped.
+    if (isBlank(left)) return isBlank(right) ? 0 : 1;
+    if (isBlank(right)) return -1;
+
+    const comparison =
+      typeof left === 'number' && typeof right === 'number'
+        ? left - right
+        : collator.compare(String(left), String(right));
+
+    return dir === 'asc' ? comparison : -comparison;
+  };
+}
+
+export function filterBooks(books, query) {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return books;
+
+  return books.filter((book) => SEARCH_FIELDS.some((field) => book[field]?.toLowerCase().includes(needle)));
+}

--- a/electron-ui/src/sorting.test.js
+++ b/electron-ui/src/sorting.test.js
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { compareBooks, filterBooks, sortKey } from './sorting';
+import { durationMinutes, formatDuration } from './format';
+
+const book = (overrides) => ({ title: 'A', author: 'A', ...overrides });
+const order = (books, field, dir = 'asc') => [...books].sort(compareBooks(field, dir));
+
+describe('durationMinutes', () => {
+  it('reads hours and minutes', () => {
+    expect(durationMinutes('12 hrs and 34 mins')).toBe(754);
+    expect(durationMinutes('1 hr and 1 min')).toBe(61);
+  });
+
+  it('reads a value with only one part', () => {
+    expect(durationMinutes('45 mins')).toBe(45);
+    expect(durationMinutes('7 hrs')).toBe(420);
+  });
+
+  it('returns null for anything it does not understand', () => {
+    expect(durationMinutes('')).toBeNull();
+    expect(durationMinutes(null)).toBeNull();
+    expect(durationMinutes('unknown')).toBeNull();
+  });
+});
+
+describe('formatDuration', () => {
+  it('abbreviates, because the column truncates the prose form to nothing useful', () => {
+    expect(formatDuration('12 hrs and 34 mins')).toBe('12h 34m');
+    expect(formatDuration('45 mins')).toBe('45m');
+    expect(formatDuration('7 hrs')).toBe('7h');
+  });
+
+  it('passes through a value it cannot parse rather than dropping it', () => {
+    expect(formatDuration('unknown')).toBe('unknown');
+  });
+
+  it('shows an em dash when there is nothing to show', () => {
+    expect(formatDuration('')).toBe('—');
+    expect(formatDuration(undefined)).toBe('—');
+  });
+});
+
+describe('sorting by duration', () => {
+  // Regression: sorting compared the raw text, so "45 mins" was read as 45 against the 9 of
+  // "9 hrs and 9 mins" and a three-quarter-hour book was filed after a nine-hour one.
+  it('orders by length, not by the leading number', () => {
+    const books = [
+      book({ title: 'nine hours', duration: '9 hrs and 9 mins' }),
+      book({ title: 'forty five minutes', duration: '45 mins' }),
+      book({ title: 'one hour', duration: '1 hr and 1 min' }),
+    ];
+
+    expect(order(books, 'duration').map((b) => b.title)).toEqual([
+      'forty five minutes',
+      'one hour',
+      'nine hours',
+    ]);
+  });
+
+  it('sinks books with an unreadable duration, in both directions', () => {
+    const books = [
+      book({ title: 'unreadable', duration: 'unknown' }),
+      book({ title: 'short', duration: '10 mins' }),
+      book({ title: 'long', duration: '10 hrs' }),
+    ];
+
+    expect(order(books, 'duration', 'asc').map((b) => b.title)).toEqual(['short', 'long', 'unreadable']);
+    expect(order(books, 'duration', 'desc').map((b) => b.title)).toEqual(['long', 'short', 'unreadable']);
+  });
+});
+
+describe('sorting by series', () => {
+  // Regression: the key was seriesName alone, so every book in a series tied and kept whatever
+  // order the export used — routinely #10 above #2.
+  it('orders books within a series by their sequence', () => {
+    const books = [
+      book({ title: 'tenth', seriesName: 'Numbers', seriesSequence: '10' }),
+      book({ title: 'second', seriesName: 'Numbers', seriesSequence: '2' }),
+      book({ title: 'first', seriesName: 'Numbers', seriesSequence: '1' }),
+    ];
+
+    expect(order(books, 'seriesName').map((b) => b.title)).toEqual(['first', 'second', 'tenth']);
+  });
+
+  it('handles a fractional sequence', () => {
+    const books = [
+      book({ title: 'two', seriesName: 'S', seriesSequence: '2' }),
+      book({ title: 'one and a half', seriesName: 'S', seriesSequence: '1.5' }),
+      book({ title: 'one', seriesName: 'S', seriesSequence: '1' }),
+    ];
+
+    expect(order(books, 'seriesName').map((b) => b.title)).toEqual(['one', 'one and a half', 'two']);
+  });
+
+  it('groups by series name before sequence', () => {
+    const books = [
+      book({ title: 'b1', seriesName: 'Bravo', seriesSequence: '1' }),
+      book({ title: 'a2', seriesName: 'Alpha', seriesSequence: '2' }),
+      book({ title: 'a1', seriesName: 'Alpha', seriesSequence: '1' }),
+    ];
+
+    expect(order(books, 'seriesName').map((b) => b.title)).toEqual(['a1', 'a2', 'b1']);
+  });
+
+  it('sinks standalone books', () => {
+    const books = [
+      book({ title: 'standalone' }),
+      book({ title: 'in a series', seriesName: 'S', seriesSequence: '1' }),
+    ];
+
+    expect(order(books, 'seriesName').map((b) => b.title)).toEqual(['in a series', 'standalone']);
+  });
+});
+
+describe('sorting by title and rating', () => {
+  it('orders titles naturally, so 2 comes before 10', () => {
+    const books = [book({ title: 'Book 10' }), book({ title: 'Book 2' }), book({ title: 'Book 1' })];
+    expect(order(books, 'title').map((b) => b.title)).toEqual(['Book 1', 'Book 2', 'Book 10']);
+  });
+
+  it('ignores case and accents when ordering', () => {
+    const books = [book({ title: 'Zebra' }), book({ title: 'Ápple' }), book({ title: 'banana' })];
+    expect(order(books, 'title').map((b) => b.title)).toEqual(['Ápple', 'banana', 'Zebra']);
+  });
+
+  it('compares ratings as numbers and sinks unrated books', () => {
+    const books = [
+      book({ title: 'unrated', aveRating: 0 }),
+      book({ title: 'good', aveRating: 4.5 }),
+      book({ title: 'better', aveRating: 4.9 }),
+    ];
+
+    expect(order(books, 'aveRating', 'desc').map((b) => b.title)).toEqual(['better', 'good', 'unrated']);
+  });
+});
+
+describe('sortKey', () => {
+  it('falls back to the named field for a plain column', () => {
+    expect(sortKey(book({ narratedBy: 'Simon Vance' }), 'narratedBy')).toBe('Simon Vance');
+  });
+});
+
+describe('filterBooks', () => {
+  const library = [
+    book({ title: 'The Hobbit', author: 'Tolkien', narratedBy: 'Rob Inglis', seriesName: 'Middle-earth' }),
+    book({ title: 'Dune', author: 'Herbert', narratedBy: 'Simon Vance' }),
+  ];
+
+  it('returns everything for a blank query', () => {
+    expect(filterBooks(library, '')).toHaveLength(2);
+    expect(filterBooks(library, '   ')).toHaveLength(2);
+  });
+
+  it('matches title, author, narrator and series', () => {
+    expect(filterBooks(library, 'hobbit')).toHaveLength(1);
+    expect(filterBooks(library, 'herbert')).toHaveLength(1);
+    expect(filterBooks(library, 'vance')).toHaveLength(1);
+    expect(filterBooks(library, 'middle')).toHaveLength(1);
+  });
+
+  it('ignores case and surrounding whitespace', () => {
+    expect(filterBooks(library, '  DUNE ')).toHaveLength(1);
+  });
+
+  it('tolerates books missing the fields it searches', () => {
+    expect(() => filterBooks([{ title: 'Only a title' }], 'title')).not.toThrow();
+  });
+});

--- a/electron-ui/tailwind.config.js
+++ b/electron-ui/tailwind.config.js
@@ -1,27 +1,51 @@
 /** @type {import('tailwindcss').Config} */
+
+// Every colour is a token defined in src/index.css. Declaring them as channel triplets keeps
+// Tailwind's opacity modifiers working (bg-surface/60, ring-accent/70).
+const token = (name) => `rgb(var(--color-${name}) / <alpha-value>)`;
+
 module.exports = {
-  content: [
-    './index.html',
-    './src/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
-        brand: {
-          50: '#eef2ff',
-          100: '#e0e7ff',
-          200: '#c7d2fe',
-          300: '#a5b4fc',
-          400: '#818cf8',
-          500: '#6366f1',
-          600: '#4f46e5',
-          700: '#4338ca',
-          800: '#3730a3',
-          900: '#312e81',
-        },
+        canvas: token('canvas'),
+        surface: token('surface'),
+        raised: token('raised'),
+        line: token('line'),
+        'line-strong': token('line-strong'),
+
+        fg: token('fg'),
+        'fg-muted': token('fg-muted'),
+        'fg-subtle': token('fg-subtle'),
+
+        accent: token('accent'),
+        'accent-hover': token('accent-hover'),
+        'accent-fg': token('accent-fg'),
+
+        positive: token('positive'),
+        caution: token('caution'),
+        critical: token('critical'),
       },
-      animation: {
-        'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        DEFAULT: 'var(--radius)',
+        lg: 'var(--radius-lg)',
+      },
+      height: {
+        control: 'var(--control-height)',
+      },
+      minHeight: {
+        control: 'var(--control-height)',
+      },
+      fontSize: {
+        // A deliberately short scale: meta, body, emphasis, section, page.
+        '2xs': ['11px', '16px'],
+        xs: ['12px', '18px'],
+        sm: ['13px', '20px'],
+        base: ['14px', '21px'],
+        lg: ['16px', '24px'],
+        xl: ['20px', '28px'],
       },
     },
   },


### PR DESCRIPTION
Stability work on the sorting engine, a test suite covering it, and the release plumbing needed to publish `3.1.0-beta.1` as a pre-release.

## What was wrong

The sorter decided folder and file names inside the parallel copy loop, and wrote those decisions back onto the shared `OpenAudible` objects held by `SortService`:

- **The library was rewritten by every sort.** `ProcessAudioFile` assigned to `audioFile.Author`, `.Title`, `.SeriesName` and so on. Those are the same instances served by `GET /api/books`, so the Library view changed after a run and a second run started from different data than the first.
- **Two spellings of an author produced two folders.** `ResolveAuthorDirectoryName` scanned the destination for an equivalent folder while other workers were creating folders, so "J.K. Rowling" and "JK Rowling" could both win in the same run.
- **Books overwrote each other silently.** Nothing reserved a destination path. Worse, `ShortTitle` is an optional column and the file name fell straight back to `"Unknown"` — an export without that column named *every* book `Unknown.m4b` in the author folder, and only the last one survived.
- **Cancelling left truncated files.** The copy wrote directly to the destination with `FileMode.Create`. The "are these the same file" check compares size plus a couple of 4 KB chunks, so a partial file of the right size was treated as already done on the next run.
- **A missing source folder was a silent no-op.** `SortAudioFiles` logged to a console nobody sees and returned, so `POST /api/sort/start` answered "Sort started" and the UI polled a run that would never report anything.
- **One bad CSV cell lost the whole library.** `Purchase Date`, `Release Date` and `Ave. Rating` were mapped without `.Optional()` and with strict converters, so a missing column or a blank rating threw and aborted the import.
- **Path handling was Linux-permissive.** Sanitisation used `Path.GetInvalidFileNameChars()`, which on Linux excludes only `/` and `\0`, so `..` survived as an author name and a value like `Vol. 2 ` produced a folder Windows would never match again.
- `IsSorting` was checked in the endpoint and again in `StartSort`, so two concurrent requests could both be told the sort had started while only one ran.
- `dotnet build` on the solution failed outright: it referenced a `WatcherService` project that is not in the repository.

## What changed

Planning is now separated from copying and runs single-threaded in list order, which is what makes the outcome deterministic:

| File | Role |
| --- | --- |
| `PathSanitizer` | Cross-platform-safe path segments, traversal and reserved-name guards, containment check |
| `BookNaming` | Metadata → names, as pure functions that never touch the book |
| `SourceFileLocator` | Finds the audio and PDF files for a book across the export's several spellings |
| `SortPlanner` | Decides and reserves every destination path before any copying starts |
| `FileSorter` | Copies the plan in parallel, atomically, reporting counts and warnings |

Behaviour that follows from that:

- Sorting is read-only with respect to the parsed library.
- Folder names are resolved once and cached, so one author gets one folder; existing folders that mean the same thing are reused, as are existing files whose names differ only in stripped characters.
- Each destination path is reserved by exactly one source file; genuine clashes get a `(2)` suffix, and a row duplicated in the export is copied once.
- Copies go to `<name>.oabo-partial` and are renamed into place, so an interrupted run leaves either a complete file or nothing.
- Names are sanitised against Windows' rules on every platform, capped at 200 characters and 200 UTF-8 bytes, with reserved device names prefixed and a final containment check against the destination root.
- Folders are only created for books that actually have something to copy.
- Audio files are found even when the `M4B`/`MP3` columns are empty, and `File Paths` entries written with Windows separators resolve on Linux and macOS.
- CSV import treats every column as optional, parses dates and numbers leniently, skips and reports individual bad rows, detects the delimiter, handles a BOM, and rejects a non-export file with an explanatory message.
- `TryStartSort` makes starting a run atomic; the API validates paths up front and refuses a destination inside the source.
- The frontend reads error bodies defensively, gives up on a backend that has stopped answering instead of spinning forever, and shows copied / skipped / failed separately.
- Electron takes a single-instance lock, notices when the backend exits, and guards window handles.

## Testing

`AudioFileSorter.Tests` — 136 tests, green on this branch:

```
Passed! - Failed: 0, Passed: 136, Skipped: 0, Total: 136
```

Covering path safety and traversal, author/series/sequence resolution, planning determinism, destination reservation, atomic and idempotent copying, cancellation, error paths, and CSV robustness.

Also verified by hand against a running backend, with a fixture library containing awkward metadata (mixed author spellings, `../../etc` as an author, `CON` as a title, punctuation in titles, missing files, a short row, an unparseable date and rating):

- Two spellings of one author merged into a single folder; "Wizarding World" and "The Wizarding World Series" merged; a `- translator` contributor stripped; the PDF companion copied alongside.
- `GET /api/books` after the sort returned the original, unmodified metadata.
- A second run reported 0 copied / 10 skipped with the file count unchanged.
- A cancelled 300-book run left 55 complete files, 0 `.oabo-partial` files and 0 truncated files; resuming copied exactly the remaining 245 and the content matched the source byte for byte.
- The self-contained Linux backend and both installers were built and the packaged binary was started and queried.

Added `.github/workflows/ci.yml`: backend build and tests on Linux and Windows, frontend build, and a Docker image build.

## Release plumbing

`release.yml` now accepts `X.Y.Z-<pre-release>`, marks such releases as pre-releases, publishes them under their exact Docker tag only so `latest` and the `X.Y` tag keep pointing at the last stable release, uses `.github/release-body-beta.md` for the notes, and runs the tests before anything is published. Verified locally that electron-builder packages `3.1.0-beta.1` correctly (the `.deb` becomes `3.1.0~beta.1`, which is the right Debian ordering).

## Notes for review

- **File names change on Linux.** Characters that are illegal on Windows are now stripped on every platform, so a library organised on Linux may see a few files renamed. Existing folders and equivalent existing files are detected and reused to keep this to a minimum, and it is called out in the beta release notes.
- **`POST /api/books/parse` now returns `{ books, skippedRows, warnings }`** instead of a bare array. The frontend accepts both shapes.
- `OpenAudible.PurchaseDate`/`ReleaseDate` became `DateTime?`; they are unused by the UI.
- `OABO_MAX_PARALLELISM` caps copy concurrency (default: cores/4, max 8) — useful when the destination is a network share.
- Dropped the stale `WatcherService` reference so `dotnet build` on the solution works again, and removed duplicate `devDependencies` keys in `package.json` that were silently reverting Dependabot's postcss bump.

Merging this makes `main` ready for the `3.1.0-beta.1` tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NqEwPow8jjegRDAbmvtoKW)_